### PR TITLE
Add a future operator and asynchronous tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,13 @@ jobs:
         xcodebuild clean build test \
         -scheme "$SCHEME" \
         -destination "$DESTINATION";
+
+    - name: Create github action link comment
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          **Build and Test** is done!\
+          \
+          You can check out [Github Action Link](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+        reactions: '+1'

--- a/README.md
+++ b/README.md
@@ -116,6 +116,6 @@ To integrate **OneWay** into your Xcode project using Swift Package Manager, add
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/DevYeom/OneWay", from: "1.0.0"),
+  .package(url: "https://github.com/DevYeom/OneWay", from: "0.1.0"),
 ]
 ```


### PR DESCRIPTION
### Added

- Future operator for SideWay
  - supporting such as API call
- Asynchronous tests