### PR TITLE
1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,31 @@
-# OneWay
+<img src="https://github.com/DevYeom/OneWay/blob/assets/oneway_logo.png" alt="oneway_logo"/>
 
-<p align="left">
+<p align="center">
   <img alt="Swift" src="https://img.shields.io/badge/Swift-5.5-orange.svg">
   <a href="https://github.com/DevYeom/OneWay/releases/latest">
     <img alt="release" src="https://img.shields.io/github/v/release/DevYeom/OneWay.svg">
   </a>
   <a href="https://github.com/DevYeom/OneWay">
-    <img alt="Platforms" src="https://img.shields.io/badge/platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS-yellow.svg">
+    <img alt="Platforms" src="https://img.shields.io/badge/platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS-lightgray.svg">
   </a>
   <a href="https://github.com/DevYeom/OneWay/actions">
     <img alt="CI" src="https://github.com/DevYeom/OneWay/workflows/CI/badge.svg">
   </a>
   <a href="LICENSE">
-    <img alt="license" src="https://img.shields.io/badge/license-MIT-lightgray.svg">
+    <img alt="license" src="https://img.shields.io/badge/license-MIT-indigo.svg">
   </a>
 </p>
 
-**OneWay** is a super simple and lightweight library for state management with unidirectional data flow. The original inspiration came from [Flux](https://github.com/facebook/flux), [The Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture), [ReactorKit](https://github.com/ReactorKit/ReactorKit) and many state management [libraries](https://github.com/tnfe/awesome-state). It's easy to learn and use. There are no dependencies on third parties, so you can use **OneWay** purely. It can not only be used in the presentation layer (e.g. with View or ViewController), but can also be used to simplify complex business logic (e.g. while the app launches). The basic concept is to think of each way separately.
+**OneWay** is a simple and lightweight library for state management with unidirectional data flow. It is fully supported for using anywhere that uses Swift. You can use it on any platform and with any framework. There are no dependencies on third parties, so you can use **OneWay** purely. It can not only be used in the presentation layer, but can also be used to simplify complex business logic. It will be useful whenever you want to design logic in unidirection.
 
 - [Data Flow](#data-flow)
 - [Usage](#usage)
+- [Documentation](#documentation)
 - [Benchmark](#benchmark)
 - [Examples](#examples)
 - [Requirements](#requirements)
 - [Installation](#installation)
+- [References](#references)
 
 ## Data Flow
 
@@ -63,6 +65,7 @@ final class CounterWay: Way<CounterWay.Action, CounterWay.State> {
             )
         }
     }
+
 }
 ```
 
@@ -77,7 +80,7 @@ way.send(.increment)
 way.send(.decrement)
 way.send(.twice)
 
-print(way.currentState.number) // 2
+print(way.state.number) // 2
 ```
 
 ### Subscribing a Way
@@ -109,7 +112,7 @@ You can easily subscribe to global states by overriding `bind()`.
 let globalTextSubject = PassthroughSubject<String, Never>()
 let globalNumberSubject = PassthroughSubject<Int, Never>()
 
-final class CustomWay: Way<CustomWay.Action, CustomWay.State> {
+final class CounterWay: Way<CounterWay.Action, CounterWay.State> {
 // ...
     override func bind() -> SideWay<Action, Never> {
         return .merge(
@@ -125,12 +128,44 @@ final class CustomWay: Way<CustomWay.Action, CustomWay.State> {
 }
 ```
 
+### Swift Concurrency
+
+`async/await` can also be used with **Way**.
+
+```swift
+final class CounterWay: Way<CounterWay.Action, CounterWay.State> {
+
+    enum Action {
+        case fetchNumber
+        case setNumber(Int)
+    }
+
+    struct State: Equatable {
+        var number: Int
+    }
+
+    override func reduce(state: inout State, action: Action) -> SideWay<Action, Never> {
+        switch action {
+        case .fetchNumber:
+            return .async {
+                let number = await fetchNumber()
+                return Action.setNumber(number)
+            }
+        case .setNumber(let number):
+            state.number = number
+            return .none
+        }
+    }
+
+}
+```
+
 ### Supporting NSObject
 
 **Way** is a class, not a protocol. Therefore, multiple inheritance is not possible. There are often situations where you have to inherit NSObject. **NSWay** was added for this occasion. In this case, inherit and implement **NSWay**, and in other cases, inherit **Way**.
 
 ```swift
-final class TestWay: NSWay<TestWay.Action, TestWay.State> {
+final class CounterWay: NSWay<CounterWay.Action, CounterWay.State> {
     // ...
 }
 ```
@@ -140,13 +175,17 @@ final class TestWay: NSWay<TestWay.Action, TestWay.State> {
 **Way** has a `ThreadOption` to consider the multithreaded environment. This option can be passed as an argument to the initializer. Once set, it cannot be changed. In a general environment, it is better to use the default option(`current`) for better performance. But, if it is initialized with the `current` option, all interactions (i.e. sending actions) with an instance of **Way** must be done on the same thread.
 
 ```swift
-let way = TestWay(initialState: initialState, threadOption: .current)
-let threadSafeWay = TestWay(initialState: initialState, threadOption: .threadSafe)
+let way = CounterWay(initialState: initialState, threadOption: .current)
+let threadSafeWay = CounterWay(initialState: initialState, threadOption: .threadSafe)
 ```
+
+## Documentation
+
+Learn how to use OneWay by going through the [documentation](https://devyeom-docs.github.io/oneway/documentation/oneway) created using DocC.
 
 ## Benchmark
 
-Compared to other libraries, **OneWay** shows very good performance. In particular, the usage is very similar to [ReactorKit](https://github.com/ReactorKit/ReactorKit), so it is easy to use, but it is about 10 times faster.
+Compared to other libraries, **OneWay** shows very good performance.
 
 For more details, 👉 [OneWayBenchmark](https://github.com/DevYeom/OneWayBenchmark)
 
@@ -159,6 +198,8 @@ For more details, 👉 [OneWayBenchmark](https://github.com/DevYeom/OneWayBenchm
 ## Examples
 
 - [OneWayExample](https://github.com/DevYeom/OneWayExample)
+  - [UIKit](https://github.com/DevYeom/OneWayExample/tree/main/CounterUIKit/Counter)
+  - [SwiftUI](https://github.com/DevYeom/OneWayExample/tree/main/CounterSwiftUI/Counter)
 
 ## Requirements
 
@@ -179,9 +220,23 @@ To integrate **OneWay** into your Xcode project using Swift Package Manager, add
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/DevYeom/OneWay", from: "0.1.0"),
+  .package(url: "https://github.com/DevYeom/OneWay", from: "1.0.0"),
 ]
 ```
+
+## Next Step
+
+- [ ] Testing queue for asynchronous test case.
+- [ ] Debugging tool that can log all actions and states.
+
+## References
+
+These are the references that inspired OneWay a lot.
+
+- [Flux](https://github.com/facebook/flux)
+- [The Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture)
+- [ReactorKit](https://github.com/ReactorKit/ReactorKit)
+- [awesome-state](https://github.com/tnfe/awesome-state)
 
 ## License
 

--- a/Sources/OneWay/AnyWay.swift
+++ b/Sources/OneWay/AnyWay.swift
@@ -3,7 +3,7 @@ import Combine
 
 internal protocol AnyWay: AnyObject {
     associatedtype Action
-    associatedtype State
+    associatedtype State: Equatable
 
     var initialState: State { get }
     var currentState: State { get }

--- a/Sources/OneWay/AnyWay.swift
+++ b/Sources/OneWay/AnyWay.swift
@@ -7,6 +7,7 @@ internal protocol AnyWay: AnyObject {
     associatedtype State: Equatable
 
     var initialState: State { get }
+    var state: State { get }
     var currentState: State { get }
     var publisher: WayPublisher<State> { get }
 

--- a/Sources/OneWay/AnyWay.swift
+++ b/Sources/OneWay/AnyWay.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 
 internal protocol AnyWay: AnyObject {
+
     associatedtype Action
     associatedtype State: Equatable
 
@@ -13,5 +14,6 @@ internal protocol AnyWay: AnyObject {
     func bind() -> SideWay<Action, Never>
     func send(_ action: Action)
     func reset()
+
 }
 

--- a/Sources/OneWay/NSWay.swift
+++ b/Sources/OneWay/NSWay.swift
@@ -9,7 +9,11 @@ open class NSWay<Action, State>: NSObject, AnyWay, ObservableObject where State:
     public var initialState: State { wrappedValue.initialState }
 
     /// The current state.
-    public var currentState: State { wrappedValue.currentState }
+    public var state: State { wrappedValue.state }
+
+    /// The current state.
+    @available(*, deprecated, renamed: "state")
+    public var currentState: State { state }
 
     /// A publisher that emits when the state changes.
     public var publisher: WayPublisher<State> { wrappedValue.publisher }

--- a/Sources/OneWay/NSWay.swift
+++ b/Sources/OneWay/NSWay.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The ``NSWay`` is useful when NSObject must be inherited. Since ``Way`` is a class, multiple
 /// inheritance is not possible. To solve this problem, it is made by wrapping the ``Way``.
-open class NSWay<Action, State>: NSObject, AnyWay {
+open class NSWay<Action, State>: NSObject, AnyWay where State: Equatable {
 
     /// A wrapped way that has an actual implementation.
     private let wrappedValue: Way<Action, State>

--- a/Sources/OneWay/NSWay.swift
+++ b/Sources/OneWay/NSWay.swift
@@ -85,11 +85,14 @@ open class NSWay<Action, State>: NSObject, AnyWay, ObservableObject where State:
     private func applyStateSubscription() {
         stateCancellable?.cancel()
         stateCancellable = wrappedValue.objectWillChange
-            .sink(receiveCompletion: { [weak self] _ in
-                self?.stateCancellable = nil
-            }, receiveValue: { [weak self] _ in
-                self?.objectWillChange.send()
-            })
+            .sink(
+                receiveCompletion: { [weak self] _ in
+                    self?.stateCancellable = nil
+                },
+                receiveValue: { [weak self] _ in
+                    self?.objectWillChange.send()
+                }
+            )
     }
 
 }

--- a/Sources/OneWay/NSWay.swift
+++ b/Sources/OneWay/NSWay.swift
@@ -70,4 +70,5 @@ open class NSWay<Action, State>: NSObject, AnyWay where State: Equatable {
     public func reset() {
         wrappedValue.reset()
     }
+
 }

--- a/Sources/OneWay/NSWay.swift
+++ b/Sources/OneWay/NSWay.swift
@@ -21,7 +21,10 @@ open class NSWay<Action, State>: NSObject, AnyWay {
     /// - Parameters:
     ///   - initialState: The state to initialize a way.
     ///   - threadOption: The option to determine thread environment. Default value is `current`
-    public init(initialState: State, threadOption: ThreadOption = .current) {
+    public init(
+        initialState: State,
+        threadOption: ThreadOption = .current
+    ) {
         self.wrappedValue = Way(initialState: initialState, threadOption: threadOption)
         super.init()
         self.wrappedValue.reduceHandler = { [weak self] state, action in
@@ -39,7 +42,10 @@ open class NSWay<Action, State>: NSObject, AnyWay {
     /// - Parameters:
     ///   - state: The current state of the way.
     ///   - action: The action that causes the current state of the way to change.
-    open func reduce(state: inout State, action: Action) -> SideWay<Action, Never> {
+    open func reduce(
+        state: inout State,
+        action: Action
+    ) -> SideWay<Action, Never> {
         return .none
     }
 
@@ -54,7 +60,9 @@ open class NSWay<Action, State>: NSObject, AnyWay {
     ///
     /// - Parameters:
     ///   - action: An action to perform `reduce(state:action:)`
-    public func send(_ action: Action) {
+    public func send(
+        _ action: Action
+    ) {
         wrappedValue.send(action)
     }
 

--- a/Sources/OneWay/SideWay.swift
+++ b/Sources/OneWay/SideWay.swift
@@ -40,6 +40,12 @@ public struct SideWay<Output, Failure: Error>: Publisher {
         )
     }
 
+    /// A sideWay that does nothing and completes immediately. Useful for situations where you must
+    /// return a sideWay, but you don't need to do anything.
+    public static var none: SideWay {
+        Empty(completeImmediately: true).eraseToSideWay()
+    }
+
     /// Transforms all elements from the upstream sideWay with a provided closure.
     ///
     /// - Parameter transform: A closure that transforms the upstream sideWay's output to a new
@@ -55,14 +61,8 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     /// A sideWay that immediately emits the value passed in.
     public static func just(
         _ value: Output
-    ) -> SideWay {
+    ) -> Self {
         self.init(Just(value).setFailureType(to: Failure.self))
-    }
-
-    /// A sideWay that does nothing and completes immediately. Useful for situations where you must
-    /// return a sideWay, but you don't need to do anything.
-    public static var none: SideWay {
-        Empty(completeImmediately: true).eraseToSideWay()
     }
 
     /// Concatenates a variadic list of sideWays together into a single sideWay, which runs the
@@ -72,7 +72,7 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     /// - Returns: A new sideWay
     public static func concat(
         _ sideWays: SideWay...
-    ) -> SideWay {
+    ) -> Self {
         .concat(sideWays)
     }
 
@@ -83,7 +83,7 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     /// - Returns: A new sideWay
     public static func concat<C: Collection>(
         _ sideWays: C
-    ) -> SideWay where C.Element == SideWay {
+    ) -> Self where C.Element == SideWay {
         guard let first = sideWays.first else { return .none }
         return sideWays
             .dropFirst()
@@ -99,7 +99,7 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     /// - Returns: A new sideWay
     public static func merge(
         _ sideWays: SideWay...
-    ) -> SideWay {
+    ) -> Self {
         .merge(sideWays)
     }
 
@@ -110,7 +110,7 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     /// - Returns: A new sideWay
     public static func merge<S: Sequence>(
         _ sideWays: S
-    ) -> SideWay where S.Element == SideWay {
+    ) -> Self where S.Element == SideWay {
         Publishers.MergeMany(sideWays).eraseToSideWay()
     }
 
@@ -120,7 +120,7 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     ///   used to feed it `Result<Output, Failure>` values.
     public static func future(
         _ result: @escaping (@escaping (Result<Output, Failure>) -> Void) -> Void
-    ) -> SideWay {
+    ) -> Self {
       Deferred { Future(result) }.eraseToSideWay()
     }
 }

--- a/Sources/OneWay/SideWay.swift
+++ b/Sources/OneWay/SideWay.swift
@@ -239,7 +239,10 @@ extension Publisher {
             .eraseToSideWay()
     }
 
-    public func empty<EmptyOutput, EmptyFailure>() -> SideWay<EmptyOutput, EmptyFailure> {
+    public func empty<EmptyOutput, EmptyFailure>(
+        outputType: EmptyOutput.Type = EmptyOutput.self,
+        failureType: EmptyFailure.Type = EmptyFailure.self
+    ) -> SideWay<EmptyOutput, EmptyFailure> {
         self.flatMap { _ in Empty<EmptyOutput, Failure>() }
             .catch { _ in Empty() }
             .eraseToSideWay()

--- a/Sources/OneWay/SideWay.swift
+++ b/Sources/OneWay/SideWay.swift
@@ -15,20 +15,24 @@ public struct SideWay<Output, Failure: Error>: Publisher {
 
     /// Initializes a sideWay that wraps a publisher. Each emission of the wrapped publisher will be
     /// emitted by the sideWay.
-    public init<P: Publisher>(_ publisher: P)
-    where P.Output == Output, P.Failure == Failure {
+    public init<P: Publisher>(
+        _ publisher: P
+    ) where P.Output == Output, P.Failure == Failure {
         self.upstream = publisher.eraseToAnyPublisher()
     }
 
-    public func receive<S>(subscriber: S)
-    where S: Combine.Subscriber, Failure == S.Failure, Output == S.Input {
+    public func receive<S>(
+        subscriber: S
+    ) where S: Combine.Subscriber, Failure == S.Failure, Output == S.Input {
         self.upstream.subscribe(subscriber)
     }
 
     /// Initializes a sideWay that immediately fails with the error passed in.
     ///
     /// - Parameter error: The error that is immediately emitted by the sideWay.
-    public init(error: Failure) {
+    public init(
+        error: Failure
+    ) {
         self.init(
             Deferred {
                 Future { $0(.failure(error)) }
@@ -42,12 +46,16 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     ///   output.
     /// - Returns: A publisher that uses the provided closure to map elements from the upstream
     ///   sideWay to new elements that it then publishes.
-    public func map<T>(_ transform: @escaping (Output) -> T) -> SideWay<T, Failure> {
+    public func map<T>(
+        _ transform: @escaping (Output) -> T
+    ) -> SideWay<T, Failure> {
         .init(self.map(transform) as Publishers.Map<Self, T>)
     }
 
     /// A sideWay that immediately emits the value passed in.
-    public static func just(_ value: Output) -> SideWay {
+    public static func just(
+        _ value: Output
+    ) -> SideWay {
         self.init(Just(value).setFailureType(to: Failure.self))
     }
 
@@ -62,7 +70,9 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     ///
     /// - Parameter sideWays: A variadic list of sideWays.
     /// - Returns: A new sideWay
-    public static func concat(_ sideWays: SideWay...) -> SideWay {
+    public static func concat(
+        _ sideWays: SideWay...
+    ) -> SideWay {
         .concat(sideWays)
     }
 
@@ -71,7 +81,9 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     ///
     /// - Parameter sideWays: A collection of sideWays.
     /// - Returns: A new sideWay
-    public static func concat<C: Collection>(_ sideWays: C) -> SideWay where C.Element == SideWay {
+    public static func concat<C: Collection>(
+        _ sideWays: C
+    ) -> SideWay where C.Element == SideWay {
         guard let first = sideWays.first else { return .none }
         return sideWays
             .dropFirst()
@@ -85,7 +97,9 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     ///
     /// - Parameter sideWays: A list of sideWays.
     /// - Returns: A new sideWay
-    public static func merge(_ sideWays: SideWay...) -> SideWay {
+    public static func merge(
+        _ sideWays: SideWay...
+    ) -> SideWay {
         .merge(sideWays)
     }
 
@@ -94,7 +108,9 @@ public struct SideWay<Output, Failure: Error>: Publisher {
     ///
     /// - Parameter sideWays: A sequence of sideWays.
     /// - Returns: A new sideWay
-    public static func merge<S: Sequence>(_ sideWays: S) -> SideWay where S.Element == SideWay {
+    public static func merge<S: Sequence>(
+        _ sideWays: S
+    ) -> SideWay where S.Element == SideWay {
         Publishers.MergeMany(sideWays).eraseToSideWay()
     }
 
@@ -116,7 +132,9 @@ extension Publisher {
     }
 
     /// Turns any publisher into a ``SideWay`` with trasfroming.
-    public func eraseToSideWay<T>(_ transform: @escaping (Output) -> T) -> SideWay<T, Failure> {
+    public func eraseToSideWay<T>(
+        _ transform: @escaping (Output) -> T
+    ) -> SideWay<T, Failure> {
         self.map(transform)
             .eraseToSideWay()
     }
@@ -149,7 +167,9 @@ extension Publisher {
     }
 
     /// Turns any publisher into a ``SideWay`` that return value instead of an error.
-    public func catchToReturn(_ value: Output) -> SideWay<Output, Never> {
+    public func catchToReturn(
+        _ value: Output
+    ) -> SideWay<Output, Never> {
         self.catch { _ in Just(value) }
             .eraseToSideWay()
     }

--- a/Sources/OneWay/SideWay.swift
+++ b/Sources/OneWay/SideWay.swift
@@ -195,25 +195,6 @@ extension SideWay {
         }
         .eraseToSideWay()
     }
-
-    /// Creates a sideWay that executes some work that doesn't have any return value.
-    /// If an error is thrown, the sideWay will complete and the error will be ignored.
-    ///
-    /// - Parameters:
-    ///   - priority: Priority of the underlying task. If `nil`, the priority will come from
-    ///     `Task.currentPriority`.
-    ///   - operation: The operation to perform.
-    /// - Returns: A new sideWay
-    public static func asyncVoid(
-        priority: TaskPriority? = nil,
-        operation: @escaping @Sendable () async throws -> Void
-    ) -> Self {
-        SideWay<Void, Never>.async(
-            priority: priority,
-            operation: { try? await operation() }
-        )
-        .empty()
-    }
 #endif
 
 }

--- a/Sources/OneWay/SideWay.swift
+++ b/Sources/OneWay/SideWay.swift
@@ -11,6 +11,7 @@ import Combine
 /// the same thread, and if the way is being used to drive UI then it must receive values on the
 /// main thread.
 public struct SideWay<Output, Failure: Error>: Publisher {
+
     public let upstream: AnyPublisher<Output, Failure>
 
     /// Initializes a sideWay that wraps a publisher. Each emission of the wrapped publisher will be
@@ -177,7 +178,7 @@ public struct SideWay<Output, Failure: Error>: Publisher {
         .eraseToSideWay()
     }
 
-    public static func asyncEmpty(
+    public static func asyncVoid(
         priority: TaskPriority? = nil,
         _ operation: @escaping @Sendable () async throws -> Void
     ) -> Self {
@@ -188,9 +189,11 @@ public struct SideWay<Output, Failure: Error>: Publisher {
         .empty()
     }
 #endif
+
 }
 
 extension Publisher {
+
     /// Turns any publisher into a ``SideWay``.
     public func eraseToSideWay() -> SideWay<Output, Failure> {
         SideWay(self)
@@ -247,4 +250,5 @@ extension Publisher {
             .catch { _ in Empty() }
             .eraseToSideWay()
     }
+
 }

--- a/Sources/OneWay/ThreadOption.swift
+++ b/Sources/OneWay/ThreadOption.swift
@@ -2,9 +2,11 @@ import Foundation
 
 /// Determines which thread environment Way will be working on.
 public enum ThreadOption {
+
     /// Run on current thread. It needs to ensure that all actions run on the same thread.
     case current
 
     /// It guarantees Way is thread-safe. Use only when absolutely necessary.
     case threadSafe
+
 }

--- a/Sources/OneWay/Way.swift
+++ b/Sources/OneWay/Way.swift
@@ -4,7 +4,7 @@ import Combine
 /// The ``Way`` represents the path through which data passes. It is the object that can not only be
 /// used in the presentation layer, but can also be used to simplify complex business logic. The
 /// basic concept is to think of each way separately.
-open class Way<Action, State>: AnyWay {
+open class Way<Action, State>: AnyWay where State: Equatable {
 
     /// The initial state.
     public let initialState: State

--- a/Sources/OneWay/Way.swift
+++ b/Sources/OneWay/Way.swift
@@ -39,7 +39,10 @@ open class Way<Action, State>: AnyWay {
     /// - Parameters:
     ///   - initialState: The state to initialize a way.
     ///   - threadOption: The option to determine thread environment. Default value is `current`
-    public init(initialState: State, threadOption: ThreadOption = .current) {
+    public init(
+        initialState: State,
+        threadOption: ThreadOption = .current
+    ) {
         defer { applyBinding() }
 
         self.initialState = initialState
@@ -59,7 +62,10 @@ open class Way<Action, State>: AnyWay {
     /// - Parameters:
     ///   - state: The current state of the way.
     ///   - action: The action that causes the current state of the way to change.
-    open func reduce(state: inout State, action: Action) -> SideWay<Action, Never> {
+    open func reduce(
+        state: inout State,
+        action: Action
+    ) -> SideWay<Action, Never> {
         return reduceHandler?(&state, action) ?? .none
     }
 
@@ -74,7 +80,9 @@ open class Way<Action, State>: AnyWay {
     ///
     /// - Parameters:
     ///   - action: An action to perform `reduce(state:action:)`
-    final public func send(_ action: Action) {
+    final public func send(
+        _ action: Action
+    ) {
         switch threadOption {
         case .current:
             consume(action)
@@ -93,7 +101,9 @@ open class Way<Action, State>: AnyWay {
         applyBinding()
     }
 
-    private func consume(_ action: Action) {
+    private func consume(
+        _ action: Action
+    ) {
         bufferedActions.append(action)
         guard !isSending else { return }
 
@@ -112,7 +122,7 @@ open class Way<Action, State>: AnyWay {
             let uuid = UUID()
             let sideWayCancellable = sideWay
                 .sink(
-                    receiveCompletion: { [uuid, weak self] _ in
+                    receiveCompletion: { [weak self, uuid] _ in
                         didComplete = true
                         self?.sideWayCancellables[uuid] = nil
                     },
@@ -151,19 +161,24 @@ public struct WayPublisher<State>: Publisher {
     private let upstream: AnyPublisher<State, Never>
     private let way: Any
 
-    internal init<Action>(way: Way<Action, State>) {
+    internal init<Action>(
+        way: Way<Action, State>
+    ) {
         self.way = way
         self.upstream = way.stateSubject.eraseToAnyPublisher()
     }
 
-    private init<P>(upstream: P, way: Any)
-    where P: Publisher, Failure == P.Failure, Output == P.Output {
+    private init<P>(
+        upstream: P,
+        way: Any
+    ) where P: Publisher, Failure == P.Failure, Output == P.Output {
         self.upstream = upstream.eraseToAnyPublisher()
         self.way = way
     }
 
-    public func receive<S>(subscriber: S)
-    where S: Subscriber, Failure == S.Failure, Output == S.Input {
+    public func receive<S>(
+        subscriber: S
+    ) where S: Subscriber, Failure == S.Failure, Output == S.Input {
         self.upstream.subscribe(
             AnySubscriber(
                 receiveSubscription: subscriber.receive(subscription:),

--- a/Sources/OneWay/Way.swift
+++ b/Sources/OneWay/Way.swift
@@ -10,7 +10,11 @@ open class Way<Action, State>: AnyWay, ObservableObject where State: Equatable {
     public let initialState: State
 
     /// The current state.
-    public var currentState: State { stateSubject.value }
+    public var state: State { stateSubject.value }
+
+    /// The current state.
+    @available(*, deprecated, renamed: "state")
+    public var currentState: State { state }
 
     /// A publisher that emits when the state changes.
     public var publisher: WayPublisher<State> {

--- a/Tests/OneWayTests/Mocks/TestMocks.swift
+++ b/Tests/OneWayTests/Mocks/TestMocks.swift
@@ -1,0 +1,6 @@
+import Foundation
+import Combine
+
+struct WayError: Error { }
+let globalTextSubject = PassthroughSubject<String, Never>()
+let globalNumberSubject = PassthroughSubject<Int, Never>()

--- a/Tests/OneWayTests/Mocks/TestNSWay.swift
+++ b/Tests/OneWayTests/Mocks/TestNSWay.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Combine
+import OneWay
+
+final class TestNSWay: NSWay<TestNSWay.Action, TestNSWay.State> {
+
+    enum Action {
+        case increment
+        case incrementMany
+        case decrement
+        case twice
+        case saveText(String)
+        case saveNumber(Int)
+        case fetchDelayedNumber
+        case fetchDelayedNumberWithError
+    }
+
+    struct State: Equatable {
+        var number: Int
+        var text: String
+    }
+
+    override func reduce(state: inout State, action: Action) -> SideWay<Action, Never> {
+        switch action {
+        case .increment:
+            state.number += 1
+            return .none
+        case .incrementMany:
+            state.number += 1
+            return state.number >= 100_000 ? .none : .just(.incrementMany)
+        case .decrement:
+            state.number -= 1
+            return .none
+        case .twice:
+            return .concat(
+                .just(.increment),
+                .just(.increment)
+            )
+        case .saveText(let text):
+            state.text = text
+            return .none
+        case .saveNumber(let number):
+            state.number = number
+            return .none
+        case .fetchDelayedNumber:
+            return SideWay<Int, Never>
+                .future { result in
+                    DispatchQueue.global().asyncAfter(
+                        deadline: .now() + .milliseconds(100),
+                        execute: {
+                            result(.success(10))
+                            result(.success(20))
+                        }
+                    )
+                }
+                .receive(on: DispatchQueue.main)
+                .map({ Action.saveNumber($0) })
+                .eraseToSideWay()
+        case .fetchDelayedNumberWithError:
+            return SideWay<Int, Error>
+                .future { result in
+                    DispatchQueue.global().asyncAfter(
+                        deadline: .now() + .milliseconds(100),
+                        execute: {
+                            result(.failure(WayError()))
+                        }
+                    )
+                }
+                .map({ Action.saveNumber($0) })
+                .catchToReturn(Action.saveNumber(-1))
+                .eraseToSideWay()
+        }
+    }
+
+    override func bind() -> SideWay<Action, Never> {
+        return .merge(
+            globalTextSubject
+                .map({ Action.saveText($0) })
+                .eraseToSideWay(),
+            globalNumberSubject
+                .map({ Action.saveNumber($0) })
+                .eraseToSideWay()
+        )
+    }
+
+}

--- a/Tests/OneWayTests/Mocks/TestWay.swift
+++ b/Tests/OneWayTests/Mocks/TestWay.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Combine
+import OneWay
+
+final class TestWay: Way<TestWay.Action, TestWay.State> {
+
+    enum Action {
+        case increment
+        case incrementMany
+        case decrement
+        case twice
+        case saveText(String)
+        case saveNumber(Int)
+        case fetchDelayedNumber
+        case fetchDelayedNumberWithError
+    }
+
+    struct State: Equatable {
+        var number: Int
+        var text: String
+    }
+
+    override func reduce(state: inout State, action: Action) -> SideWay<Action, Never> {
+        switch action {
+        case .increment:
+            state.number += 1
+            return .none
+        case .incrementMany:
+            state.number += 1
+            return state.number >= 100_000 ? .none : .just(.incrementMany)
+        case .decrement:
+            state.number -= 1
+            return .none
+        case .twice:
+            return .concat(
+                .just(.increment),
+                .just(.increment)
+            )
+        case .saveText(let text):
+            state.text = text
+            return .none
+        case .saveNumber(let number):
+            state.number = number
+            return .none
+        case .fetchDelayedNumber:
+            return SideWay<Int, Never>
+                .future { result in
+                    DispatchQueue.global().asyncAfter(
+                        deadline: .now() + .milliseconds(100),
+                        execute: {
+                            result(.success(10))
+                            result(.success(20))
+                        }
+                    )
+                }
+                .receive(on: DispatchQueue.main)
+                .map({ Action.saveNumber($0) })
+                .eraseToSideWay()
+        case .fetchDelayedNumberWithError:
+            return SideWay<Int, Error>
+                .future { result in
+                    DispatchQueue.global().asyncAfter(
+                        deadline: .now() + .milliseconds(100),
+                        execute: {
+                            result(.failure(WayError()))
+                        }
+                    )
+                }
+                .map({ Action.saveNumber($0) })
+                .catchToReturn(Action.saveNumber(-1))
+                .eraseToSideWay()
+        }
+    }
+
+    override func bind() -> SideWay<Action, Never> {
+        return .merge(
+            globalTextSubject
+                .map({ Action.saveText($0) })
+                .eraseToSideWay(),
+            globalNumberSubject
+                .map({ Action.saveNumber($0) })
+                .eraseToSideWay()
+        )
+    }
+
+}

--- a/Tests/OneWayTests/NSWayTests.swift
+++ b/Tests/OneWayTests/NSWayTests.swift
@@ -32,23 +32,23 @@ final class NSWayTests: XCTestCase {
         way.send(.twice)
         way.send(.decrement)
 
-        XCTAssertEqual(way.currentState.number, 2)
+        XCTAssertEqual(way.state.number, 2)
     }
 
     func test_bindGlobalSubjects() {
         let way = TestNSWay(initialState: .init(number: 0, text: ""))
 
         globalNumberSubject.send(10)
-        XCTAssertEqual(way.currentState.number, 10)
+        XCTAssertEqual(way.state.number, 10)
         globalNumberSubject.send(20)
-        XCTAssertEqual(way.currentState.number, 20)
+        XCTAssertEqual(way.state.number, 20)
         globalNumberSubject.send(30)
-        XCTAssertEqual(way.currentState.number, 30)
+        XCTAssertEqual(way.state.number, 30)
 
         globalTextSubject.send("Hello")
-        XCTAssertEqual(way.currentState.text, "Hello")
+        XCTAssertEqual(way.state.text, "Hello")
         globalTextSubject.send("World")
-        XCTAssertEqual(way.currentState.text, "World")
+        XCTAssertEqual(way.state.text, "World")
     }
 
     func test_receiveWithRemovingDuplicates() {
@@ -98,7 +98,7 @@ final class NSWayTests: XCTestCase {
     func test_lotsOfSynchronousActions() {
         let way = TestNSWay(initialState: .init(number: 0, text: ""))
         way.send(.incrementMany)
-        XCTAssertEqual(way.currentState.number, 100_000)
+        XCTAssertEqual(way.state.number, 100_000)
     }
 
     func test_threadSafeSendingActions() {
@@ -129,7 +129,7 @@ final class NSWayTests: XCTestCase {
 
         let expectation = expectation(description: "\(#function)")
         wait(seconds: 5, expectation: expectation, queue: queue)
-        XCTAssertEqual(way.currentState.number, 30_000)
+        XCTAssertEqual(way.state.number, 30_000)
     }
 
     func test_asynchronousSideWaySuccessInMainThread() {
@@ -142,21 +142,21 @@ final class NSWayTests: XCTestCase {
             .store(in: &cancellables)
 
         way.send(.fetchDelayedNumber)
-        XCTAssertEqual(way.currentState.number, 0)
+        XCTAssertEqual(way.state.number, 0)
 
         let expectation = expectation(description: "\(#function)")
         wait(milliseconds: 200, expectation: expectation)
-        XCTAssertEqual(way.currentState.number, 10)
+        XCTAssertEqual(way.state.number, 10)
     }
 
     func test_asynchronousSideWayFailure() {
         let way = TestNSWay(initialState: .init(number: 0, text: ""))
         way.send(.fetchDelayedNumberWithError)
-        XCTAssertEqual(way.currentState.number, 0)
+        XCTAssertEqual(way.state.number, 0)
 
         let expectation = expectation(description: "\(#function)")
         wait(milliseconds: 200, expectation: expectation)
-        XCTAssertEqual(way.currentState.number, -1)
+        XCTAssertEqual(way.state.number, -1)
     }
 
 }

--- a/Tests/OneWayTests/SideWayTests.swift
+++ b/Tests/OneWayTests/SideWayTests.swift
@@ -243,18 +243,6 @@ final class SideWayTests: XCTestCase {
     }
 
 #if canImport(_Concurrency)
-    func test_asyncEmpty() {
-        SideWay<Int, Never>.asyncVoid { [weak self] in
-            self?.number = await twelve()
-        }
-        .sink(receiveValue: { _ in XCTFail() })
-        .store(in: &cancellables)
-
-        let expectation = expectation(description: "\(#function)")
-        wait(milliseconds: 10, expectation: expectation)
-        XCTAssertEqual(number, 12)
-    }
-
     func test_asyncNeverFailureWithReturnValue() {
         var result: Int?
         SideWay<Int, Never>.async {

--- a/Tests/OneWayTests/SideWayTests.swift
+++ b/Tests/OneWayTests/SideWayTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+import Combine
+import OneWay
+
+final class SideWayTests: XCTestCase {
+
+    private var number: Int?
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUp() {
+        number = nil
+    }
+
+    func test_concat() {
+        var numbers: [Int] = []
+        SideWay<Int, Never>.concat(
+            .just(1)
+            .delay(for: .milliseconds(20), scheduler: DispatchQueue.main)
+            .handleEvents(receiveOutput: { _ in XCTAssertEqual(numbers, []) })
+            .eraseToSideWay(),
+            .just(2)
+            .delay(for: .milliseconds(10), scheduler: DispatchQueue.main)
+            .handleEvents(receiveOutput: { _ in XCTAssertEqual(numbers, [1]) })
+            .eraseToSideWay(),
+            .just(3)
+            .handleEvents(receiveOutput: { _ in XCTAssertEqual(numbers, [1, 2]) })
+            .eraseToSideWay()
+        )
+        .sink(receiveValue: { numbers.append($0) })
+        .store(in: &cancellables)
+
+        let expectation = expectation(description: "\(#function)")
+        wait(milliseconds: 100, expectation: expectation)
+        XCTAssertEqual(numbers, [1, 2, 3])
+    }
+
+    func test_merge() {
+        var numbers: [Int] = []
+        SideWay<Int, Never>.merge(
+            .just(1)
+            .delay(for: .milliseconds(20), scheduler: DispatchQueue.main)
+            .handleEvents(receiveOutput: { _ in XCTAssertEqual(numbers, [3, 2]) })
+            .eraseToSideWay(),
+            .just(2)
+            .delay(for: .milliseconds(10), scheduler: DispatchQueue.main)
+            .handleEvents(receiveOutput: { _ in XCTAssertEqual(numbers, [3]) })
+            .eraseToSideWay(),
+            .just(3)
+            .handleEvents(receiveOutput: { _ in XCTAssertEqual(numbers, []) })
+            .eraseToSideWay()
+        )
+        .sink(receiveValue: { numbers.append($0) })
+        .store(in: &cancellables)
+
+        let expectation = expectation(description: "\(#function)")
+        wait(milliseconds: 100, expectation: expectation)
+        XCTAssertEqual(numbers, [3, 2, 1])
+    }
+
+#if canImport(_Concurrency)
+    func test_asyncEmpty() {
+        SideWay<Int, Never>.asyncEmpty { [weak self] in
+            self?.number = await twelve()
+        }
+        .sink(receiveValue: { _ in XCTFail() })
+        .store(in: &cancellables)
+
+        let expectation = expectation(description: "\(#function)")
+        wait(milliseconds: 10, expectation: expectation)
+        XCTAssertEqual(number, 12)
+    }
+
+    func test_asyncNeverFailureWithReturnValue() {
+        var result: Int?
+        SideWay<Int, Never>.async {
+            return await twelve()
+        }
+        .sink(receiveValue: { result = $0 })
+        .store(in: &cancellables)
+
+        let expectation = expectation(description: "\(#function)")
+        wait(milliseconds: 10, expectation: expectation)
+        XCTAssertEqual(result, 12)
+    }
+
+    func test_asyncFailureWithReturnValue() {
+        var result: Int?
+        SideWay<Int, Error>.async {
+            return await twelve()
+        }
+        .sink(
+            receiveCompletion: { _ in },
+            receiveValue: { result = $0 }
+        )
+        .store(in: &cancellables)
+
+        let expectation = expectation(description: "\(#function)")
+        wait(milliseconds: 10, expectation: expectation)
+        XCTAssertEqual(result, 12)
+    }
+
+    func test_asyncThrowsError() {
+        var result: Error?
+        SideWay<Int, Error>.async {
+            return try await twelveWithError()
+        }
+        .sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    XCTFail()
+                case let .failure(error):
+                    result = error
+                }
+            },
+            receiveValue: { _ in XCTFail() }
+        )
+        .store(in: &cancellables)
+
+        let expectation = expectation(description: "\(#function)")
+        wait(milliseconds: 10, expectation: expectation)
+        XCTAssertNotNil(result)
+    }
+#endif
+}
+
+@Sendable
+private func twelve() async -> Int {
+    try? await Task.sleep(nanoseconds: NSEC_PER_MSEC)
+    return 12
+}
+
+@Sendable
+private func twelveWithError() async throws -> Int {
+    try? await Task.sleep(nanoseconds: NSEC_PER_MSEC)
+    throw SideWayError()
+}
+
+private struct SideWayError: Error {}

--- a/Tests/OneWayTests/SideWayTests.swift
+++ b/Tests/OneWayTests/SideWayTests.swift
@@ -244,7 +244,7 @@ final class SideWayTests: XCTestCase {
 
 #if canImport(_Concurrency)
     func test_asyncEmpty() {
-        SideWay<Int, Never>.asyncEmpty { [weak self] in
+        SideWay<Int, Never>.asyncVoid { [weak self] in
             self?.number = await twelve()
         }
         .sink(receiveValue: { _ in XCTFail() })
@@ -310,6 +310,7 @@ final class SideWayTests: XCTestCase {
 
 }
 
+#if canImport(_Concurrency)
 @Sendable
 private func twelve() async -> Int {
     try? await Task.sleep(nanoseconds: NSEC_PER_MSEC) // 1ms
@@ -321,3 +322,4 @@ private func twelveWithError() async throws -> Int {
     try? await Task.sleep(nanoseconds: NSEC_PER_MSEC) // 1ms
     throw WayError()
 }
+#endif

--- a/Tests/OneWayTests/TestHelper.swift
+++ b/Tests/OneWayTests/TestHelper.swift
@@ -3,21 +3,57 @@ import Combine
 import XCTest
 
 extension XCTestCase {
-    func wait(seconds: Int, expectation: XCTestExpectation, queue: DispatchQueue = .main) {
-        wait(milliseconds: seconds * 1000, expectation: expectation, queue: queue)
+    func wait(
+        seconds: Int,
+        expectation: XCTestExpectation,
+        queue: DispatchQueue = .main
+    ) {
+        wait(
+            milliseconds: seconds * 1000,
+            expectation: expectation,
+            queue: queue
+        )
     }
 
-    func wait(seconds: Int, expectations: [XCTestExpectation], queue: DispatchQueue = .main) {
-        wait(milliseconds: seconds * 1000, expectations: expectations, queue: queue)
+    func wait(
+        seconds: Int,
+        expectations: [XCTestExpectation],
+        queue: DispatchQueue = .main
+    ) {
+        wait(
+            milliseconds: seconds * 1000,
+            expectations: expectations,
+            queue: queue
+        )
     }
 
-    func wait(milliseconds: Int, expectation: XCTestExpectation, queue: DispatchQueue = .main) {
-        queue.asyncAfter(deadline: .now() + .milliseconds(milliseconds)) { expectation.fulfill() }
-        wait(for: [expectation], timeout: 10)
+    func wait(
+        milliseconds: Int,
+        expectation: XCTestExpectation,
+        queue: DispatchQueue = .main
+    ) {
+        queue.asyncAfter(
+            deadline: .now() + .milliseconds(milliseconds),
+            execute: { expectation.fulfill() }
+        )
+        wait(
+            for: [expectation],
+            timeout: 10
+        )
     }
 
-    func wait(milliseconds: Int, expectations: [XCTestExpectation], queue: DispatchQueue = .main) {
-        queue.asyncAfter(deadline: .now() + .milliseconds(milliseconds)) { expectations.forEach { $0.fulfill() } }
-        wait(for: expectations, timeout: 10)
+    func wait(
+        milliseconds: Int,
+        expectations: [XCTestExpectation],
+        queue: DispatchQueue = .main
+    ) {
+        queue.asyncAfter(
+            deadline: .now() + .milliseconds(milliseconds),
+            execute: { expectations.forEach { $0.fulfill() } }
+        )
+        wait(
+            for: expectations,
+            timeout: 10
+        )
     }
 }

--- a/Tests/OneWayTests/WayTests.swift
+++ b/Tests/OneWayTests/WayTests.swift
@@ -25,23 +25,23 @@ final class WayTests: XCTestCase {
         way.send(.twice)
         way.send(.decrement)
 
-        XCTAssertEqual(way.currentState.number, 2)
+        XCTAssertEqual(way.state.number, 2)
     }
 
     func test_bindGlobalSubjects() {
         let way = TestWay(initialState: .init(number: 0, text: ""))
 
         globalNumberSubject.send(10)
-        XCTAssertEqual(way.currentState.number, 10)
+        XCTAssertEqual(way.state.number, 10)
         globalNumberSubject.send(20)
-        XCTAssertEqual(way.currentState.number, 20)
+        XCTAssertEqual(way.state.number, 20)
         globalNumberSubject.send(30)
-        XCTAssertEqual(way.currentState.number, 30)
+        XCTAssertEqual(way.state.number, 30)
 
         globalTextSubject.send("Hello")
-        XCTAssertEqual(way.currentState.text, "Hello")
+        XCTAssertEqual(way.state.text, "Hello")
         globalTextSubject.send("World")
-        XCTAssertEqual(way.currentState.text, "World")
+        XCTAssertEqual(way.state.text, "World")
     }
 
     func test_receiveWithRemovingDuplicates() {
@@ -91,7 +91,7 @@ final class WayTests: XCTestCase {
     func test_lotsOfSynchronousActions() {
         let way = TestWay(initialState: .init(number: 0, text: ""))
         way.send(.incrementMany)
-        XCTAssertEqual(way.currentState.number, 100_000)
+        XCTAssertEqual(way.state.number, 100_000)
     }
 
     func test_threadSafeSendingActions() {
@@ -135,21 +135,21 @@ final class WayTests: XCTestCase {
             .store(in: &cancellables)
 
         way.send(.fetchDelayedNumber)
-        XCTAssertEqual(way.currentState.number, 0)
+        XCTAssertEqual(way.state.number, 0)
 
         let expectation = expectation(description: "\(#function)")
         wait(milliseconds: 200, expectation: expectation)
-        XCTAssertEqual(way.currentState.number, 10)
+        XCTAssertEqual(way.state.number, 10)
     }
 
     func test_asynchronousSideWayFailure() {
         let way = TestWay(initialState: .init(number: 0, text: ""))
         way.send(.fetchDelayedNumberWithError)
-        XCTAssertEqual(way.currentState.number, 0)
+        XCTAssertEqual(way.state.number, 0)
 
         let expectation = expectation(description: "\(#function)")
         wait(milliseconds: 200, expectation: expectation)
-        XCTAssertEqual(way.currentState.number, -1)
+        XCTAssertEqual(way.state.number, -1)
     }
 
 }


### PR DESCRIPTION
### Added

- Add async operators in SideWay for `async/await`
- Add unit tests for SideWay

### Changed

- Way adopt `ObservableObject`
- Way's State should conform `Equatable`
- Rename `currentState` to `state` in Way