### PR TITLE
1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ final class CounterWay: Way<CounterWay.Action, CounterWay.State> {
 
 ### Catching Errors
 
-There are several functions handling errors. It is a little easier to understand if you refer to [unit tests](https://github.com/DevYeom/OneWay/blob/main/Tests/OneWayTests/SideWayTests.swift#L116-L213).
+There are several functions that handle errors. It is a little easier to understand if you refer to [unit tests](https://github.com/DevYeom/OneWay/blob/main/Tests/OneWayTests/SideWayTests.swift#L116-L213).
 
 ```swift
 override func reduce(state: inout State, action: Action) -> SideWay<Action, Never> {

--- a/Sources/OneWay/SideWay.swift
+++ b/Sources/OneWay/SideWay.swift
@@ -216,7 +216,7 @@ extension Publisher {
 
     /// Turns any publisher into a ``SideWay`` that return a output by transforming its error.
     public func `catch`(
-        _ transform: @escaping (Error) -> Output
+        _ transform: @escaping (Failure) -> Output
     ) -> SideWay<Output, Never> {
         self.catch { Just(transform($0)) }
             .eraseToSideWay()

--- a/Sources/OneWay/SideWay.swift
+++ b/Sources/OneWay/SideWay.swift
@@ -35,6 +35,9 @@ public struct SideWay<Output, Failure: Error>: Publisher {
         )
     }
 
+    /// Attaches the specified subscriber to this publisher.
+    ///
+    /// - Parameter subscriber: The subscriber to attach to this ``Publisher``, after which it can receive values.
     public func receive<S>(
         subscriber: S
     ) where S: Combine.Subscriber, Failure == S.Failure, Output == S.Input {

--- a/Sources/OneWay/Way.swift
+++ b/Sources/OneWay/Way.swift
@@ -206,6 +206,9 @@ public struct WayPublisher<State>: Publisher {
         self.way = way
     }
 
+    /// Attaches the specified subscriber to this publisher.
+    ///
+    /// - Parameter subscriber: The subscriber to attach to this ``Publisher``, after which it can receive values.
     public func receive<S>(
         subscriber: S
     ) where S: Subscriber, Failure == S.Failure, Output == S.Input {
@@ -221,6 +224,10 @@ public struct WayPublisher<State>: Publisher {
         )
     }
 
+    /// Returns the resulting publisher with partial state corresponding to a given key path.
+    ///
+    /// - Parameter dynamicMember: a key path for the original state.
+    /// - Returns: A new publisher that has a part of the original state.
     public subscript<LocalState>(
         dynamicMember keyPath: KeyPath<State, LocalState>
     ) -> WayPublisher<LocalState> where LocalState: Equatable {

--- a/Tests/OneWayTests/WayTests.swift
+++ b/Tests/OneWayTests/WayTests.swift
@@ -120,9 +120,11 @@ final class WayTests: XCTestCase {
             }
         }
 
-        let expectation = expectation(description: "\(#function)")
-        wait(seconds: 5, expectation: expectation, queue: queue)
-        XCTAssertEqual(way.state.number, 30_000)
+        group.notify(queue: queue) { [self] in
+            let expectation = expectation(description: "\(#function)")
+            wait(seconds: 1, expectation: expectation, queue: queue)
+            XCTAssertEqual(way.state.number, 30_000)
+        }
     }
 
     func test_asynchronousSideWaySuccessInMainThread() {


### PR DESCRIPTION
### Changed

- Change a assertion position of the thread-safe test

### Fixed

- Fix the `catch` operator's parameter type