### PR TITLE
Add a store running on MainActor

### DIFF
--- a/Sources/OneWay/AnyEffect.swift
+++ b/Sources/OneWay/AnyEffect.swift
@@ -9,22 +9,19 @@ import Foundation
 
 public struct AnyEffect<Element>: Effect where Element: Sendable {
     public var completion: (() -> Void)? {
-        get {
-            base.completion
-        }
-        set {
-            base.completion = newValue
-        }
+        get { base.completion }
+        set { base.completion = newValue }
     }
+
+    public var values: AsyncStream<Element> {
+        base.values
+    }
+
     private var base: any Effect<Element>
 
     public init<Base>(_ base: Base)
     where Base: Effect, Base.Element == Element {
         self.base = base
-    }
-
-    public var values: AsyncStream<Element> {
-        base.values
     }
 }
 

--- a/Sources/OneWay/Store.swift
+++ b/Sources/OneWay/Store.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-public actor Store<Action, State> where Action: Sendable, State: Equatable {
+public actor Store<R: Reducer>
+where R.Action: Sendable, R.State: Equatable {
+    public typealias Action = R.Action
+    public typealias State = R.State
+
     public var state: State {
         didSet {
             if oldValue != state {
@@ -23,10 +27,10 @@ public actor Store<Action, State> where Action: Sendable, State: Equatable {
     private var actionQueue: [Action] = []
     private var tasks: [UUID: Task<Void, Never>] = [:]
 
-    public init<R: Reducer>(
+    public init(
         reducer: @autoclosure () -> R,
         state: State
-    ) where R.Action == Action, R.State == State {
+    ) {
         self.state = state
         self.reducer = reducer()
         (states, continuation) = AsyncStream<State>.makeStream()

--- a/Sources/OneWay/Store.swift
+++ b/Sources/OneWay/Store.swift
@@ -8,7 +8,13 @@
 import Foundation
 
 public actor Store<Action, State> where Action: Sendable, State: Equatable {
-    public var state: State { didSet { continuation.yield(state) } }
+    public var state: State {
+        didSet {
+            if oldValue != state {
+                continuation.yield(state)
+            }
+        }
+    }
     public var states: AsyncStream<State>
 
     private let reducer: any Reducer<Action, State>
@@ -24,6 +30,7 @@ public actor Store<Action, State> where Action: Sendable, State: Equatable {
         self.state = state
         self.reducer = reducer()
         (states, continuation) = AsyncStream<State>.makeStream()
+        defer { continuation.yield(state) }
     }
 
     public func send(_ action: Action) async {

--- a/Sources/OneWay/ViewStore.swift
+++ b/Sources/OneWay/ViewStore.swift
@@ -1,0 +1,52 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import Foundation
+
+@MainActor
+public final class ViewStore<Action, State>: ObservableObject
+where Action: Sendable, State: Equatable {
+    public var state: State { didSet { continuation.yield(state) } }
+    public var states: AsyncStream<State>
+
+    private let store: Store<Action, State>
+    private let continuation: AsyncStream<State>.Continuation
+    private var task: Task<Void, Never>?
+
+    public init<R: Reducer>(
+        reducer: @autoclosure () -> R,
+        state: State
+    ) where R.Action == Action, R.State == State {
+        self.state = state
+        self.store = Store(
+            reducer: reducer(),
+            state: state
+        )
+        (states, continuation) = AsyncStream<State>.makeStream()
+        self.task = Task { await observe() }
+        defer { continuation.yield(state) }
+    }
+
+    deinit {
+        continuation.finish()
+        task?.cancel()
+        task = nil
+    }
+
+    public func send(_ action: Action) {
+        Task {
+            await store.send(action)
+        }
+    }
+
+    private func observe() async {
+        let states = await store.states
+        for await state in states {
+            self.state = state
+        }
+    }
+}

--- a/Sources/OneWay/ViewStore.swift
+++ b/Sources/OneWay/ViewStore.swift
@@ -8,19 +8,22 @@
 import Foundation
 
 @MainActor
-public final class ViewStore<Action, State>: ObservableObject
-where Action: Sendable, State: Equatable {
+public final class ViewStore<R: Reducer>: ObservableObject
+where R.Action: Sendable, R.State: Equatable {
+    public typealias Action = R.Action
+    public typealias State = R.State
+
     public var state: State { didSet { continuation.yield(state) } }
     public var states: AsyncStream<State>
 
-    private let store: Store<Action, State>
+    private let store: Store<R>
     private let continuation: AsyncStream<State>.Continuation
     private var task: Task<Void, Never>?
 
-    public init<R: Reducer>(
+    public init(
         reducer: @autoclosure () -> R,
         state: State
-    ) where R.Action == Action, R.State == State {
+    ) {
         self.state = state
         self.store = Store(
             reducer: reducer(),

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -9,7 +9,7 @@ import OneWay
 import XCTest
 
 final class StoreTests: XCTestCase {
-    private var sut: Store<TestReducer.Action, TestReducer.State>!
+    private var sut: Store<TestReducer>!
 
     override func setUp() {
         super.setUp()

--- a/Tests/OneWayTests/ViewStoreTests.swift
+++ b/Tests/OneWayTests/ViewStoreTests.swift
@@ -1,0 +1,75 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import OneWay
+import XCTest
+
+@MainActor
+final class ViewStoreTests: XCTestCase {
+    private var sut: ViewStore<TestReducer.Action, TestReducer.State>!
+
+    override func setUp() {
+        super.setUp()
+        sut = ViewStore(
+            reducer: TestReducer(),
+            state: .init(count: 0)
+        )
+    }
+
+    func test_initialState() async {
+        XCTAssertEqual(sut.state.count, 0)
+
+        for await state in sut.states {
+            XCTAssertEqual(state.count, 0)
+            XCTAssertEqual(Thread.isMainThread, true)
+            break
+        }
+    }
+
+    func test_sendSeveralActions() async {
+        sut.send(.increment)
+        sut.send(.increment)
+        sut.send(.decrement)
+        sut.send(.twice)
+
+        while sut.state.count < 3 {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(sut.state.count, 3)
+    }
+}
+
+fileprivate final class TestReducer: Reducer {
+    enum Action: Sendable {
+        case increment
+        case decrement
+        case twice
+    }
+
+    struct State: Equatable {
+        var count: Int
+    }
+
+    func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
+        switch action {
+        case .increment:
+            state.count += 1
+            return .none
+
+        case .decrement:
+            state.count -= 1
+            return .none
+
+        case .twice:
+            return .merge(
+                .just(.increment),
+                .just(.increment)
+            )
+        }
+    }
+}

--- a/Tests/OneWayTests/ViewStoreTests.swift
+++ b/Tests/OneWayTests/ViewStoreTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 @MainActor
 final class ViewStoreTests: XCTestCase {
-    private var sut: ViewStore<TestReducer.Action, TestReducer.State>!
+    private var sut: ViewStore<TestReducer>!
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
### Related Issues 💭

### Description 📝

- Add a `ViewStore` to ensure it runs on the main thread, making it usable in UI layers, such as `View`
- Simplify the generic type of the Store
  - AS-IS: `Store<Action, State>`
  - TO-BE: `Store<Reducer>`

### Additional Notes 📚

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
