### PR TITLE
Adopt @dynamicMemberLookup to store's state stream

### DIFF
--- a/Tests/OneWayTests/ViewStoreTests.swift
+++ b/Tests/OneWayTests/ViewStoreTests.swift
@@ -42,6 +42,21 @@ final class ViewStoreTests: XCTestCase {
 
         XCTAssertEqual(sut.state.count, 3)
     }
+
+    func test_dynamicMemberStream() async {
+        sut.send(.increment)
+        sut.send(.increment)
+        sut.send(.decrement)
+        sut.send(.decrement)
+
+        var result: [Int] = []
+        for await count in sut.states.count {
+            result.append(count)
+            if result.count > 4 { break }
+        }
+
+        XCTAssertEqual(result, [0, 1, 2, 1, 0])
+    }
 }
 
 fileprivate final class TestReducer: Reducer {


### PR DESCRIPTION
### Related Issues 💭

### Description 📝

- To easily receive state's property values, adopt `@dynamicMemberLookup` to store's state stream

### Additional Notes 📚

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
