### PR TITLE
Add some propertyWrappers for more convenient state management

### DIFF
--- a/Sources/OneWay/PropertyWrappers/Heap.swift
+++ b/Sources/OneWay/PropertyWrappers/Heap.swift
@@ -1,0 +1,60 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import Foundation
+
+/// When applied to a field, the corresponding value will always be heap-allocated.
+/// This happens because this wrapper is a class and classes are always heap-allocated.
+///
+/// Use of this wrapper is required on large value types
+/// because they can overflow the Swift runtime stack.
+///
+/// - SeeAlso: [`CopyOnWrite.swift` located in `square/wire` repository](https://github.com/square/wire/blob/master/wire-runtime-swift/src/main/swift/propertyWrappers/CopyOnWrite.swift)
+@propertyWrapper
+public struct Heap<Value> {
+    fileprivate final class Storage {
+        var value: Value
+
+        init(_ value: Value) {
+            self.value = value
+        }
+    }
+
+    public var wrappedValue: Value {
+        get {
+            storage.value
+        }
+
+        set {
+            if isKnownUniquelyReferenced(&storage) {
+                storage.value = newValue
+            } else {
+                storage = Storage(newValue)
+            }
+        }
+    }
+
+    private var storage: Storage
+
+    public init(wrappedValue: Value) {
+        storage = Storage(wrappedValue)
+    }
+}
+
+extension Heap: Sendable where Value: Sendable { }
+extension Heap: Equatable where Value: Equatable {
+    public static func == (lhs: Heap, rhs: Heap) -> Bool {
+        lhs.wrappedValue == rhs.wrappedValue
+    }
+}
+extension Heap: Hashable where Value : Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(wrappedValue)
+    }
+}
+
+extension Heap.Storage: @unchecked Sendable where Value: Sendable { }

--- a/Sources/OneWay/PropertyWrappers/Insensitive.swift
+++ b/Sources/OneWay/PropertyWrappers/Insensitive.swift
@@ -1,0 +1,27 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+@propertyWrapper
+public struct Insensitive<Value> {
+    public var wrappedValue: Value
+
+    public init(wrappedValue: Value) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+extension Insensitive: Sendable where Value: Sendable { }
+extension Insensitive: Equatable where Value: Equatable {
+    public static func == (lhs: Insensitive, rhs: Insensitive) -> Bool {
+        true
+    }
+}
+extension Insensitive: Hashable where Value: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(wrappedValue)
+    }
+}

--- a/Sources/OneWay/PropertyWrappers/Sensitive.swift
+++ b/Sources/OneWay/PropertyWrappers/Sensitive.swift
@@ -1,0 +1,57 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import Foundation
+
+@propertyWrapper
+public struct Sensitive<Value> where Value: Equatable {
+    fileprivate struct Storage: Equatable {
+        var value: Value
+        var version: UInt8
+
+        init(_ value: Value) {
+            self.value = value
+            self.version = .min
+        }
+
+        mutating func set(_ value: Value) {
+            if self.value == value {
+                self.version &+= 1
+            } else {
+                self.value = value
+                self.version = .min
+            }
+        }
+    }
+
+    public var wrappedValue: Value {
+        get { storage.value }
+        set { storage.set(newValue) }
+    }
+
+    private var storage: Storage
+
+    public init(wrappedValue: Value) {
+        storage = Storage(wrappedValue)
+    }
+}
+
+extension Sensitive: Sendable where Value: Sendable { }
+extension Sensitive: Equatable { }
+extension Sensitive: Hashable where Value: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(storage)
+    }
+}
+
+extension Sensitive.Storage: Sendable where Value: Sendable { }
+extension Sensitive.Storage: Hashable where Value: Hashable {
+    fileprivate func hash(into hasher: inout Hasher) {
+        hasher.combine(value)
+        hasher.combine(version)
+    }
+}

--- a/Tests/OneWayTests/PropertyWrappersTests.swift
+++ b/Tests/OneWayTests/PropertyWrappersTests.swift
@@ -1,0 +1,116 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import OneWay
+import XCTest
+
+final class PropertyWrappersTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
+    func test_heap() {
+        struct Storage {
+            @Heap var value: Int
+            @Heap var optionalValue: Int?
+        }
+
+        do {
+            var storage = Storage(value: 10, optionalValue: 10)
+            XCTAssertEqual(storage.value, 10)
+            XCTAssertEqual(storage.optionalValue, 10)
+
+            storage.value = 20
+            storage.optionalValue = nil
+            XCTAssertEqual(storage.value, 20)
+            XCTAssertEqual(storage.optionalValue, nil)
+
+            storage.value = 30
+            storage.optionalValue = 20
+            XCTAssertEqual(storage.value, 30)
+            XCTAssertEqual(storage.optionalValue, 20)
+        }
+
+        do {
+            var storage = Storage(value: 10, optionalValue: nil)
+            XCTAssertEqual(storage.value, 10)
+            XCTAssertEqual(storage.optionalValue, nil)
+
+            storage.value = 20
+            storage.optionalValue = 10
+            XCTAssertEqual(storage.value, 20)
+            XCTAssertEqual(storage.optionalValue, 10)
+
+            storage.value = 30
+            storage.optionalValue = nil
+            XCTAssertEqual(storage.value, 30)
+            XCTAssertEqual(storage.optionalValue, nil)
+        }
+    }
+
+    func test_sensitive() {
+        struct Storage: Equatable {
+            @Sensitive var value: Int
+        }
+
+        do {
+            let old = Storage(value: 10)
+            var new = old
+            new.value = 20
+
+            XCTAssertNotEqual(old, new)
+        }
+
+        do {
+            let old = Storage(value: 10)
+            var new = old
+            new.value = 10
+
+            XCTAssertNotEqual(old, new)
+        }
+
+        do {
+            var old = Storage(value: 10)
+            var new = old
+            old.value = 20
+            new.value = 20
+
+            XCTAssertEqual(old, new)
+        }
+    }
+
+    func test_insensitive() {
+        struct Storage: Equatable {
+            @Insensitive var value: Int
+        }
+
+        do {
+            let old = Storage(value: 10)
+            var new = old
+            new.value = 20
+
+            XCTAssertEqual(old, new)
+        }
+
+        do {
+            let old = Storage(value: 10)
+            var new = old
+            new.value = 10
+
+            XCTAssertEqual(old, new)
+        }
+
+        do {
+            var old = Storage(value: 10)
+            var new = old
+            old.value = 20
+            new.value = 20
+
+            XCTAssertEqual(old, new)
+        }
+    }
+}

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -35,15 +35,14 @@ final class StoreTests: XCTestCase {
     func test_sendSeveralActions() async {
         await sut.send(.increment)
         await sut.send(.increment)
-        await sut.send(.decrement)
         await sut.send(.twice)
 
-        while await sut.state.count < 3 {
+        while await sut.state.count < 4 {
             await Task.yield()
         }
 
         let state = await sut.state
-        XCTAssertEqual(state.count, 3)
+        XCTAssertEqual(state.count, 4)
         XCTAssertEqual(state.text, "")
     }
 
@@ -122,7 +121,6 @@ fileprivate final class TestReducer: Reducer {
     enum Action: Sendable {
         case increment
         case incrementMany
-        case decrement
         case twice
         case request
         case response(String)
@@ -142,10 +140,6 @@ fileprivate final class TestReducer: Reducer {
         case .incrementMany:
             state.count += 1
             return state.count >= 100_000 ? .none : .just(.incrementMany)
-
-        case .decrement:
-            state.count -= 1
-            return .none
 
         case .twice:
             return .merge(


### PR DESCRIPTION
### Related Issues 💭

### Description 📝

- Add @Heap, @Sensitive, @Insensitive for more convenient state management
- Fix unintentional test cases so that they do not hang, as these are cases where the lack of guaranteed order is not considered due to asynchronous behavior.

### Additional Notes 📚

```swift
struct State {
    @Heap var value: Int
    @Sensitive var sensitiveValue: Int
    @Insensitive var insensitiveValue: Int
}
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
