### PR TITLE
Add a sequence effect to receive values from an AsyncSequence

### DIFF
--- a/Sources/OneWay/AnyEffect.swift
+++ b/Sources/OneWay/AnyEffect.swift
@@ -50,6 +50,17 @@ extension AnyEffect {
     }
 
     @inlinable
+    public static func sequence(
+        priority: TaskPriority? = nil,
+        operation: @escaping ((Element) -> Void) async -> Void
+    ) -> AnyEffect<Element> {
+        Effects.Sequence(
+            priority: priority,
+            operation: operation
+        ).any
+    }
+
+    @inlinable
     public static func concat(
         priority: TaskPriority? = nil,
         _ effects: AnyEffect<Element>...

--- a/Tests/OneWayTests/EffectTests.swift
+++ b/Tests/OneWayTests/EffectTests.swift
@@ -47,6 +47,48 @@ final class EffectTests: XCTestCase {
         XCTAssertEqual(result, [.first])
     }
 
+    func test_sequence() async {
+        let stream = AsyncStream { continuation in
+            for number in 1 ... 5 {
+                continuation.yield(number)
+            }
+            continuation.finish()
+        }
+
+        let values = Effects.Sequence { send in
+            for await number in stream {
+                let action: Action
+                switch number {
+                case 1: action = .first
+                case 2: action = .second
+                case 3: action = .third
+                case 4: action = .fourth
+                case 5: action = .fifth
+                default:
+                    action = .first
+                    XCTFail()
+                }
+                send(action)
+            }
+        }.values
+
+        var result: [Action] = []
+        for await value in values {
+            result.append(value)
+        }
+
+        XCTAssertEqual(
+            result,
+            [
+                .first,
+                .second,
+                .third,
+                .fourth,
+                .fifth,
+            ]
+        )
+    }
+
     func test_concat() async {
         let clock = TestClock()
 


### PR DESCRIPTION
### Related Issues 💭

### Description 📝

- Add a sequence effect to receive values from an `AsyncSequence`

### Additional Notes 📚

```swift
// In a reducer
return .sequence { send in
    for await value in values {
        send(Action.response(value))
    }
}
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
