### PR TITLE
Adopt CustomStringConvertible to property wrappers

### DIFF
--- a/Sources/OneWay/PropertyWrappers/Heap.swift
+++ b/Sources/OneWay/PropertyWrappers/Heap.swift
@@ -45,6 +45,12 @@ public struct Heap<Value> {
     }
 }
 
+extension Heap: CustomStringConvertible {
+    public var description: String {
+        String(describing: storage.value)
+    }
+}
+
 extension Heap: Sendable where Value: Sendable { }
 extension Heap: Equatable where Value: Equatable {
     public static func == (lhs: Heap, rhs: Heap) -> Bool {

--- a/Sources/OneWay/PropertyWrappers/Insensitive.swift
+++ b/Sources/OneWay/PropertyWrappers/Insensitive.swift
@@ -14,6 +14,12 @@ public struct Insensitive<Value> {
     }
 }
 
+extension Insensitive: CustomStringConvertible {
+    public var description: String {
+        String(describing: wrappedValue)
+    }
+}
+
 extension Insensitive: Sendable where Value: Sendable { }
 extension Insensitive: Equatable where Value: Equatable {
     public static func == (lhs: Insensitive, rhs: Insensitive) -> Bool {

--- a/Sources/OneWay/PropertyWrappers/Sensitive.swift
+++ b/Sources/OneWay/PropertyWrappers/Sensitive.swift
@@ -40,6 +40,12 @@ public struct Sensitive<Value> where Value: Equatable {
     }
 }
 
+extension Sensitive: CustomStringConvertible {
+    public var description: String {
+        String(describing: storage.value)
+    }
+}
+
 extension Sensitive: Sendable where Value: Sendable { }
 extension Sensitive: Equatable { }
 extension Sensitive: Hashable where Value: Hashable {


### PR DESCRIPTION
### Related Issues 💭

### Description 📝

To print an object in a simple manner when using the `print` statement, adopt `CustomStringConvertible` for property wrappers.

### Additional Notes 📚

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
