### PR TITLE
Add a bind function to receive global events

### DIFF
--- a/Sources/OneWay/Reducer.swift
+++ b/Sources/OneWay/Reducer.swift
@@ -11,5 +11,13 @@ public protocol Reducer<Action, State>: Sendable {
     associatedtype Action: Sendable
     associatedtype State: Equatable
 
+    func bind() -> AnyEffect<Action>
     func reduce(state: inout State, action: Action) -> AnyEffect<Action>
+}
+
+extension Reducer {
+    public func bind() -> AnyEffect<Action> {
+        // Default implementation
+        return .none
+    }
 }

--- a/Sources/OneWay/ViewStore.swift
+++ b/Sources/OneWay/ViewStore.swift
@@ -41,9 +41,11 @@ where R.Action: Sendable, R.State: Equatable {
     }
 
     public func send(_ action: Action) {
-        Task {
-            await store.send(action)
-        }
+        Task { await store.send(action) }
+    }
+
+    public func reset() {
+        Task { await store.reset() }
     }
 
     private func observe() async {

--- a/Tests/OneWayTests/EffectTests.swift
+++ b/Tests/OneWayTests/EffectTests.swift
@@ -9,7 +9,7 @@ import Clocks
 import OneWay
 import XCTest
 
-@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 final class EffectTests: XCTestCase {
     enum Action: Sendable {
         case first

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -5,9 +5,11 @@
 //  Copyright (c) 2022 SeungYeop Yeom ( https://github.com/DevYeom ).
 //
 
+import Combine
 import OneWay
 import XCTest
 
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 final class StoreTests: XCTestCase {
     private var sut: Store<TestReducer>!
 
@@ -96,6 +98,28 @@ final class StoreTests: XCTestCase {
         XCTAssertEqual(state.text, "Success")
     }
 
+    func test_bind() async {
+        var result: Set<String> = []
+
+        // https://forums.swift.org/t/how-to-use-combine-publisher-with-swift-concurrency-publisher-values-could-miss-events/67193
+        Task {
+            try! await Task.sleep(nanoseconds: NSEC_PER_MSEC)
+            textPublisher.send("first")
+            numberPublisher.send(1)
+            try! await Task.sleep(nanoseconds: NSEC_PER_MSEC)
+            textPublisher.send("second")
+            numberPublisher.send(2)
+        }
+
+        let states = await sut.states
+        for await state in states {
+            result.insert(state.text)
+            if result.count > 4 { break }
+        }
+
+        XCTAssertEqual(result, ["", "first", "1", "second", "2"])
+    }
+
     func test_removeDuplicates() async {
         await sut.send(.response("First"))
         await sut.send(.response("First"))
@@ -117,6 +141,10 @@ final class StoreTests: XCTestCase {
     }
 }
 
+private let textPublisher = PassthroughSubject<String, Never>()
+private let numberPublisher = PassthroughSubject<Int, Never>()
+
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 fileprivate final class TestReducer: Reducer {
     enum Action: Sendable {
         case increment
@@ -156,5 +184,20 @@ fileprivate final class TestReducer: Reducer {
             state.text = response
             return .none
         }
+    }
+
+    func bind() -> AnyEffect<Action> {
+        return .merge(
+            .sequence { send in
+                for await text in textPublisher.values {
+                    send(Action.response(text))
+                }
+            },
+            .sequence { send in
+                for await number in numberPublisher.values {
+                    send(Action.response(String(number)))
+                }
+            }
+        )
     }
 }


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

Add a bind function to receive global events.

### Additional Notes 📚

```swift
func bind() -> AnyEffect<Action> {
    return .merge(
        .sequence { send in
            for await value in values {
                send(Action.response(value))
            }
        },
        .sequence { send in
            for await value in otherValues {
                send(Action.response(value))
            }
        }
    )
}
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
