### PR TITLE
Mark sendable explicitly to ensure strict concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,3 +39,10 @@ let package = Package(
         ),
     ]
 )
+
+//for target in package.targets {
+//    target.swiftSettings = target.swiftSettings ?? []
+//    target.swiftSettings?.append(
+//        .enableExperimentalFeature("StrictConcurrency")
+//    )
+//}

--- a/Sources/OneWay/AnyEffect.swift
+++ b/Sources/OneWay/AnyEffect.swift
@@ -12,7 +12,7 @@ public struct AnyEffect<Element>: Effect where Element: Sendable {
     public var values: AsyncStream<Element> { base.values }
 
     private var base: any Effect<Element>
-    
+
     /// Creates a type-erasing effect to wrap the provided effect.
     ///
     /// - Parameter base: An effect to wrap with a type-eraser.
@@ -51,7 +51,7 @@ extension AnyEffect {
     @inlinable
     public static func async(
         priority: TaskPriority? = nil,
-        operation: @escaping () async -> Element
+        operation: @Sendable @escaping () async -> Element
     ) -> AnyEffect<Element> {
         Effects.Async(
             priority: priority,
@@ -70,7 +70,7 @@ extension AnyEffect {
     @inlinable
     public static func sequence(
         priority: TaskPriority? = nil,
-        operation: @escaping ((Element) -> Void) async -> Void
+        operation: @Sendable @escaping ((Element) -> Void) async -> Void
     ) -> AnyEffect<Element> {
         Effects.Sequence(
             priority: priority,

--- a/Sources/OneWay/Effect.swift
+++ b/Sources/OneWay/Effect.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 /// Effects are returned from reducers, allowing the ``Store`` to execute them once the reducer has
 /// finished its operation.
-public protocol Effect<Element> {
+public protocol Effect<Element>: Sendable {
     associatedtype Element: Sendable
 
     /// The elements produced by the effect, as an asynchronous sequence.
@@ -31,7 +31,7 @@ extension Effect {
 public enum Effects {
     /// An effect that does nothing and finishes immediately. It is useful for situations where you
     /// must return a effect, but you don't need to do anything.
-    public struct Empty<Element: Sendable>: Effect {
+    public struct Empty<Element>: Effect where Element: Sendable {
         /// Initializes a `Empty` effect.
         public init() { }
 
@@ -43,7 +43,7 @@ public enum Effects {
     }
 
     /// An effect that immediately emits the value passed in.
-    public struct Just<Element: Sendable>: Effect {
+    public struct Just<Element>: Effect where Element: Sendable {
         private let element: Element
 
         /// Initializes a `Just` effect.
@@ -62,9 +62,9 @@ public enum Effects {
     }
 
     /// An effect that can supply a single value asynchronously in the future.
-    public struct Async<Element: Sendable>: Effect {
+    public struct Async<Element>: Effect where Element: Sendable {
         private let priority: TaskPriority?
-        private let operation: () async -> Element
+        private let operation: @Sendable () async -> Element
 
         /// Initializes a `Async` effect.
         ///
@@ -74,7 +74,7 @@ public enum Effects {
         ///   - operation: The operation to perform.
         public init(
             priority: TaskPriority? = nil,
-            operation: @escaping () async -> Element
+            operation: @Sendable @escaping () async -> Element
         ) {
             self.priority = priority
             self.operation = operation
@@ -93,9 +93,9 @@ public enum Effects {
 
     /// An effect that can supply multiple values asynchronously in the future. It can be used for
     /// observing an asynchronous sequence.
-    public struct Sequence<Element: Sendable>: Effect {
+    public struct Sequence<Element>: Effect where Element: Sendable {
         private let priority: TaskPriority?
-        private let operation: ((Element) -> Void) async -> Void
+        private let operation: @Sendable ((Element) -> Void) async -> Void
 
         /// Initializes a `Sequence` effect.
         ///
@@ -105,7 +105,7 @@ public enum Effects {
         ///   - operation: The operation to perform.
         public init(
             priority: TaskPriority? = nil,
-            operation: @escaping ((Element) -> Void) async -> Void
+            operation: @Sendable @escaping ((Element) -> Void) async -> Void
         ) {
             self.priority = priority
             self.operation = operation
@@ -157,7 +157,7 @@ public enum Effects {
         }
     }
 
-    /// An effect that merges a list of effects together into a single effect, which runs the 
+    /// An effect that merges a list of effects together into a single effect, which runs the
     /// effects at the same time.
     public struct Merge<Element>: Effect where Element: Sendable {
         private let priority: TaskPriority?

--- a/Sources/OneWay/Reducer.swift
+++ b/Sources/OneWay/Reducer.swift
@@ -9,15 +9,15 @@ import Foundation
 
 /// A protocol defining a reduce fuction to transition the current state to the next state and a
 /// bind function for observing global states.
-public protocol Reducer<Action, State>: Sendable {
-    associatedtype Action: Sendable
+public protocol Reducer<Action, State> {
+    associatedtype Action
     associatedtype State: Equatable
 
     func bind() -> AnyEffect<Action>
     func reduce(state: inout State, action: Action) -> AnyEffect<Action>
 }
 
-extension Reducer {
+extension Reducer where Action: Sendable {
     public func bind() -> AnyEffect<Action> {
         // Default implementation
         return .none

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -66,17 +66,18 @@ final class StoreTests: XCTestCase {
 
     func test_threadSafeSendingActions() async {
         let iterations: Int = 10_000
+        let sut = sut!
         DispatchQueue.concurrentPerform(
             iterations: iterations / 2,
             execute: { _ in
                 Task.detached {
-                    await self.sut.send(.increment)
+                    await sut.send(.increment)
                 }
             }
         )
         for _ in 0 ..< iterations / 2 {
             Task.detached {
-                await self.sut.send(.increment)
+                await sut.send(.increment)
             }
         }
 


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

Resolved potential issues in Swift 6 by enabling the `StrictConcurrency` option.

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
