### PR TITLE
Improve dynamic shared stream for safe value sharing

### DIFF
--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -149,7 +149,7 @@ private let textPublisher = PassthroughSubject<String, Never>()
 private let numberPublisher = PassthroughSubject<Int, Never>()
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-fileprivate final class TestReducer: Reducer {
+private final class TestReducer: Reducer {
     enum Action: Sendable {
         case increment
         case incrementMany


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

Resolved the issue of missing initial values when creating a new `AsyncSequence` via the subscript of `DynamicSharedStream`.

### Additional Notes 📚

```swift
// number <- 10, 20

Task {
    for await state in sut.states {
        print(state.number) // 10, 20
    }
}

Task {
    for await number in sut.states.number {
        print(number) // 10, 20
    }
}
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
