### PR TITLE
Add asynchronous sequences for ViewStore

### DIFF
--- a/Sources/OneWay/AsyncSequences/AsyncRemoveDuplicatesSequence.swift
+++ b/Sources/OneWay/AsyncSequences/AsyncRemoveDuplicatesSequence.swift
@@ -1,0 +1,56 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import Foundation
+
+/// An asynchronous sequence that treats consecutive repeated values as unique values.
+public struct AsyncRemoveDuplicatesSequence<Base>: AsyncSequence
+where Base: AsyncSequence, Base.Element: Equatable {
+    public typealias Element = Base.Element
+
+    /// The iterator for an `AsyncRemoveDuplicatesSequence` instance.
+    public struct Iterator: AsyncIteratorProtocol {
+        @usableFromInline
+        var iterator: Base.AsyncIterator
+
+        @usableFromInline
+        var last: Element?
+
+        @usableFromInline
+        init(_ iterator: Base.AsyncIterator) {
+            self.iterator = iterator
+        }
+
+        @inlinable
+        public mutating func next() async rethrows -> Element? {
+            guard let last else {
+                self.last = try await iterator.next()
+                return self.last
+            }
+            while let element = try await iterator.next() {
+                guard last != element else { continue }
+                self.last = element
+                return element
+            }
+            return nil
+        }
+    }
+
+    @usableFromInline
+    let base: Base
+
+    init(_ base: Base) {
+        self.base = base
+    }
+
+    @inlinable
+    public func makeAsyncIterator() -> Iterator {
+        Iterator(base.makeAsyncIterator())
+    }
+}
+
+extension AsyncRemoveDuplicatesSequence: Sendable where Base: Sendable, Base.Element: Sendable { }

--- a/Sources/OneWay/AsyncSequences/AsyncViewStateSequence.swift
+++ b/Sources/OneWay/AsyncSequences/AsyncViewStateSequence.swift
@@ -1,0 +1,79 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import Foundation
+
+/// An asynchronous sequence of the ``ViewStore``'s state.
+///
+/// This stream supports dynamic member lookup so that you can pluck out a specific field in the
+/// state.
+@MainActor
+@dynamicMemberLookup
+public final class AsyncViewStateSequence<State>: AsyncSequence {
+    public typealias Element = State
+
+    /// The iterator for an `AsyncViewStateSequence` instance.
+    public struct Iterator: AsyncIteratorProtocol {
+        public typealias Element = State
+
+        @usableFromInline
+        var iterator: AsyncStream<Element>.Iterator
+
+        @usableFromInline
+        init(_ iterator: AsyncStream<Element>.Iterator) {
+            self.iterator = iterator
+        }
+
+        @inlinable
+        public mutating func next() async -> Element? {
+            await iterator.next()
+        }
+    }
+
+    @usableFromInline
+    let upstream: AsyncStream<Element>
+
+    private var continuations: [AsyncStream<Element>.Continuation] = []
+    private var last: Element?
+
+    public init(_ upstream: AsyncStream<Element>) {
+        self.upstream = upstream
+    }
+
+    deinit {
+        continuations.forEach { $0.finish() }
+    }
+
+    @inlinable
+    public nonisolated func makeAsyncIterator() -> Iterator {
+        Iterator(upstream.makeAsyncIterator())
+    }
+
+    func send(_ element: Element) {
+        last = element
+        for continuation in continuations {
+            continuation.yield(element)
+        }
+    }
+
+    /// Returns the resulting stream with partial state corresponding to the given key path.
+    ///
+    /// - Parameter dynamicMember: a key path for the original state.
+    /// - Returns: A new stream that has a part of the original state.
+    public subscript<Property>(
+        dynamicMember keyPath: KeyPath<State, Property>
+    ) -> AsyncRemoveDuplicatesSequence<AsyncMapSequence<AsyncStream<State>, Property>> {
+        let (stream, continuation) = AsyncStream<Element>.makeStream()
+        continuations.append(continuation)
+        if let last {
+            continuation.yield(last)
+        }
+        return AsyncRemoveDuplicatesSequence(stream.map { $0[keyPath: keyPath] })
+    }
+}
+
+extension AsyncViewStateSequence: Sendable where State: Sendable { }


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

- Added `AsyncRemoveDuplicatesSequence`
- Renamed `DynamicSharedStream` to `AsyncViewStateSequence` 

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
