### PR TITLE
Add test cases for a sensitive or insensitive state's property

### DIFF
--- a/Sources/OneWay/AsyncSequences/AsyncViewStateSequence.swift
+++ b/Sources/OneWay/AsyncSequences/AsyncViewStateSequence.swift
@@ -13,7 +13,8 @@ import Foundation
 /// state.
 @MainActor
 @dynamicMemberLookup
-public final class AsyncViewStateSequence<State>: AsyncSequence {
+public final class AsyncViewStateSequence<State>: AsyncSequence
+where State: Equatable {
     public typealias Element = State
 
     /// The iterator for an `AsyncViewStateSequence` instance.
@@ -66,13 +67,13 @@ public final class AsyncViewStateSequence<State>: AsyncSequence {
     /// - Returns: A new stream that has a part of the original state.
     public subscript<Property>(
         dynamicMember keyPath: KeyPath<State, Property>
-    ) -> AsyncRemoveDuplicatesSequence<AsyncMapSequence<AsyncStream<State>, Property>> {
+    ) -> AsyncMapSequence<AsyncRemoveDuplicatesSequence<AsyncStream<State>>, Property> {
         let (stream, continuation) = AsyncStream<Element>.makeStream()
         continuations.append(continuation)
         if let last {
             continuation.yield(last)
         }
-        return AsyncRemoveDuplicatesSequence(stream.map { $0[keyPath: keyPath] })
+        return AsyncRemoveDuplicatesSequence(stream).map { $0[keyPath: keyPath] }
     }
 }
 


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

- Added test cases to check whether ViewStore's State behaves as expected when using `@Sensitive` and `@Insensitive`.

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
