### PR TITLE
Improve unstable test cases

### DIFF
--- a/Sources/OneWay/AsyncSequences/AsyncDistinctSequence.swift
+++ b/Sources/OneWay/AsyncSequences/AsyncDistinctSequence.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An asynchronous sequence that treats consecutive repeated values as unique values.
-public struct AsyncRemoveDuplicatesSequence<Base>: AsyncSequence
+public struct AsyncDistinctSequence<Base>: AsyncSequence
 where Base: AsyncSequence, Base.Element: Equatable {
     public typealias Element = Base.Element
 
@@ -53,4 +53,4 @@ where Base: AsyncSequence, Base.Element: Equatable {
     }
 }
 
-extension AsyncRemoveDuplicatesSequence: Sendable where Base: Sendable, Base.Element: Sendable { }
+extension AsyncDistinctSequence: Sendable where Base: Sendable, Base.Element: Sendable { }

--- a/Sources/OneWay/AsyncSequences/AsyncViewStateSequence.swift
+++ b/Sources/OneWay/AsyncSequences/AsyncViewStateSequence.swift
@@ -67,13 +67,13 @@ where State: Equatable {
     /// - Returns: A new stream that has a part of the original state.
     public subscript<Property>(
         dynamicMember keyPath: KeyPath<State, Property>
-    ) -> AsyncMapSequence<AsyncRemoveDuplicatesSequence<AsyncStream<State>>, Property> {
+    ) -> AsyncMapSequence<AsyncDistinctSequence<AsyncStream<State>>, Property> {
         let (stream, continuation) = AsyncStream<Element>.makeStream()
         continuations.append(continuation)
         if let last {
             continuation.yield(last)
         }
-        return AsyncRemoveDuplicatesSequence(stream).map { $0[keyPath: keyPath] }
+        return AsyncDistinctSequence(stream).map { $0[keyPath: keyPath] }
     }
 }
 

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -110,7 +110,6 @@ final class StoreTests: XCTestCase {
             try! await Task.sleep(nanoseconds: NSEC_PER_MSEC)
             textPublisher.send("first")
             numberPublisher.send(1)
-            try! await Task.sleep(nanoseconds: NSEC_PER_MSEC)
             textPublisher.send("second")
             numberPublisher.send(2)
         }
@@ -193,12 +192,12 @@ private final class TestReducer: Reducer {
     func bind() -> AnyEffect<Action> {
         return .merge(
             .sequence { send in
-                for await text in textPublisher.values {
+                for await text in textPublisher.stream {
                     send(Action.response(text))
                 }
             },
             .sequence { send in
-                for await number in numberPublisher.values {
+                for await number in numberPublisher.stream {
                     send(Action.response(String(number)))
                 }
             }

--- a/Tests/OneWayTests/TestHelper/Publisher+Async.swift
+++ b/Tests/OneWayTests/TestHelper/Publisher+Async.swift
@@ -1,0 +1,24 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import Combine
+import Foundation
+
+extension Publisher where Failure == Never {
+    public var stream: AsyncStream<Output> {
+        AsyncStream { continuation in
+            let cancellable = self.sink { completion in
+                continuation.finish()
+            } receiveValue: { value in
+                 continuation.yield(value)
+            }
+            continuation.onTermination = { continuation in
+                cancellable.cancel()
+            }
+        }
+    }
+}

--- a/Tests/OneWayTests/ViewStoreTests.swift
+++ b/Tests/OneWayTests/ViewStoreTests.swift
@@ -145,14 +145,14 @@ final class ViewStoreTests: XCTestCase {
         )
     }
 
-    func test_asyncRemoveDuplicatesSequence() async {
+    func test_asyncDistinctSequence() async {
         let expectation = expectation(description: #function)
 
         let result = Result(expectation, target: 20)
         Task {
             await withTaskGroup(of: Void.self) { group in
-                group.addTask { await self.consumeAsyncViewStateSequence2(result) }
-                group.addTask { await self.consumeAsyncViewStateSequence3(result) }
+                group.addTask { await self.consumeAsyncDistinctSequence1(result) }
+                group.addTask { await self.consumeAsyncDistinctSequence2(result) }
             }
         }
 
@@ -184,6 +184,18 @@ extension ViewStoreTests {
     }
 
     private func consumeAsyncViewStateSequence3(_ result: Result) async {
+        for await count in sut.states.count {
+            await result.insert(count)
+        }
+    }
+
+    private func consumeAsyncDistinctSequence1(_ result: Result) async {
+        for await count in sut.states.count {
+            await result.insert(count)
+        }
+    }
+
+    private func consumeAsyncDistinctSequence2(_ result: Result) async {
         for await count in sut.states.count {
             await result.insert(count)
         }


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

- Improved test cases that occasionally fail depending.
- Renamed `AsyncRemoveDuplicatesSequence` to `AsyncDistinctSequence`.

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
