### PR TITLE
Rename Async to Single which is one of the effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ for await state in store.states {
 
 ### Various Effects
 
-**OneWay** supports various effects such as `just`, `concat`, `merge`, `async`, `sequence`, and more. For more details, please refer to the [documentation](https://swiftpackageindex.com/devyeom/oneway/main/documentation/oneway/effects).
+**OneWay** supports various effects such as `just`, `concat`, `merge`, `single`, `sequence`, and more. For more details, please refer to the [documentation](https://swiftpackageindex.com/devyeom/oneway/main/documentation/oneway/effects).
 
 ### Global States
 

--- a/Sources/OneWay/AnyEffect.swift
+++ b/Sources/OneWay/AnyEffect.swift
@@ -49,11 +49,11 @@ extension AnyEffect {
     ///   - operation: The operation to perform.
     /// - Returns: A new effect.
     @inlinable
-    public static func async(
+    public static func single(
         priority: TaskPriority? = nil,
         operation: @Sendable @escaping () async -> Element
     ) -> AnyEffect<Element> {
-        Effects.Async(
+        Effects.Single(
             priority: priority,
             operation: operation
         ).any

--- a/Sources/OneWay/Effect.swift
+++ b/Sources/OneWay/Effect.swift
@@ -61,7 +61,7 @@ public enum Effects {
     }
 
     /// An effect that can supply a single value asynchronously in the future.
-    public struct Async<Element>: Effect where Element: Sendable {
+    public struct Single<Element>: Effect where Element: Sendable {
         private let priority: TaskPriority?
         private let operation: @Sendable () async -> Element
 

--- a/Tests/OneWayTests/EffectTests.swift
+++ b/Tests/OneWayTests/EffectTests.swift
@@ -33,7 +33,7 @@ final class EffectTests: XCTestCase {
     func test_async() async {
         let clock = TestClock()
 
-        let values = Effects.Async {
+        let values = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.first
         }.values
@@ -93,15 +93,15 @@ final class EffectTests: XCTestCase {
         let clock = TestClock()
 
         let first = Effects.Just(Action.first).any
-        let second = Effects.Async {
+        let second = Effects.Single {
             try! await clock.sleep(for: .seconds(300))
             return Action.second
         }.any
-        let third = Effects.Async {
+        let third = Effects.Single {
             try! await clock.sleep(for: .seconds(200))
             return Action.third
         }.any
-        let fourth = Effects.Async {
+        let fourth = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.fourth
         }.any
@@ -137,23 +137,23 @@ final class EffectTests: XCTestCase {
     func test_concatIncludingMerge() async {
         let clock = TestClock()
 
-        let first = Effects.Async {
+        let first = Effects.Single {
             try! await clock.sleep(for: .seconds(500))
             return Action.first
         }.any
-        let second = Effects.Async {
+        let second = Effects.Single {
             try! await clock.sleep(for: .seconds(200))
             return Action.second
         }.any
-        let third = Effects.Async {
+        let third = Effects.Single {
             try! await clock.sleep(for: .seconds(300))
             return Action.third
         }.any
-        let fourth = Effects.Async {
+        let fourth = Effects.Single {
             try! await clock.sleep(for: .seconds(400))
             return Action.fourth
         }.any
-        let fifth = Effects.Async {
+        let fifth = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.fifth
         }.any
@@ -185,23 +185,23 @@ final class EffectTests: XCTestCase {
     func test_merge() async {
         let clock = TestClock()
 
-        let first = Effects.Async {
+        let first = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.first
         }.any
-        let second = Effects.Async {
+        let second = Effects.Single {
             try! await clock.sleep(for: .seconds(200))
             return Action.second
         }.any
-        let third = Effects.Async {
+        let third = Effects.Single {
             try! await clock.sleep(for: .seconds(300))
             return Action.third
         }.any
-        let fourth = Effects.Async {
+        let fourth = Effects.Single {
             try! await clock.sleep(for: .seconds(400))
             return Action.fourth
         }.any
-        let fifth = Effects.Async {
+        let fifth = Effects.Single {
             try! await clock.sleep(for: .seconds(500))
             return Action.fifth
         }.any
@@ -235,23 +235,23 @@ final class EffectTests: XCTestCase {
     func test_mergeIncludingConcat() async {
         let clock = TestClock()
 
-        let first = Effects.Async {
+        let first = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.first
         }.any
-        let second = Effects.Async {
+        let second = Effects.Single {
             try! await clock.sleep(for: .seconds(300))
             return Action.second
         }.any
-        let third = Effects.Async {
+        let third = Effects.Single {
             try! await clock.sleep(for: .seconds(200))
             return Action.third
         }.any
-        let fourth = Effects.Async {
+        let fourth = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.fourth
         }.any
-        let fifth = Effects.Async {
+        let fifth = Effects.Single {
             try! await clock.sleep(for: .seconds(600 + 100))
             return Action.fifth
         }.any

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -179,7 +179,7 @@ private final class TestReducer: Reducer {
             )
 
         case .request:
-            return .async {
+            return .single {
                 return Action.response("Success")
             }
 


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

- Renamed `Effects.Async` to `Effects.Single` for a clearer representation of the functionality.

### Additional Notes 📚

```swift
func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
    switch action {
// ...
    case .request:
        return .single {
            return Action.increment
        }
// ...
    }
}
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
