### PR TITLE
Rename any to eraseToAnyEffect for clarity

### DIFF
--- a/Sources/OneWay/AnyEffect.swift
+++ b/Sources/OneWay/AnyEffect.swift
@@ -27,7 +27,7 @@ extension AnyEffect {
     /// must return a effect, but you don't need to do anything.
     @inlinable
     public static var none: AnyEffect<Element> {
-        Effects.Empty().any
+        Effects.Empty().eraseToAnyEffect()
     }
 
     /// An effect that immediately emits the value passed in.
@@ -38,7 +38,7 @@ extension AnyEffect {
     public static func just(
         _ element: Element
     ) -> AnyEffect<Element> {
-        Effects.Just(element).any
+        Effects.Just(element).eraseToAnyEffect()
     }
 
     /// An effect that can supply a single value asynchronously in the future.
@@ -56,7 +56,7 @@ extension AnyEffect {
         Effects.Single(
             priority: priority,
             operation: operation
-        ).any
+        ).eraseToAnyEffect()
     }
 
     /// An effect that can supply multiple values asynchronously in the future. It can be used for
@@ -75,7 +75,7 @@ extension AnyEffect {
         Effects.Sequence(
             priority: priority,
             operation: operation
-        ).any
+        ).eraseToAnyEffect()
     }
 
     /// An effect that concatenates a list of effects together into a single effect, which runs the
@@ -94,7 +94,7 @@ extension AnyEffect {
         Effects.Concat(
             priority: priority,
             effects
-        ).any
+        ).eraseToAnyEffect()
     }
 
     /// An effect that merges a list of effects together into a single effect, which runs the
@@ -113,6 +113,6 @@ extension AnyEffect {
         Effects.Merge(
             priority: priority,
             effects
-        ).any
+        ).eraseToAnyEffect()
     }
 }

--- a/Sources/OneWay/Effect.swift
+++ b/Sources/OneWay/Effect.swift
@@ -21,7 +21,8 @@ public protocol Effect<Element>: Sendable {
 }
 
 extension Effect {
-    public var any: AnyEffect<Element> {
+    /// Wraps this effect with a type eraser.
+    public func eraseToAnyEffect() -> AnyEffect<Element> {
         AnyEffect(self)
     }
 }

--- a/Tests/OneWayTests/EffectTests.swift
+++ b/Tests/OneWayTests/EffectTests.swift
@@ -92,20 +92,20 @@ final class EffectTests: XCTestCase {
     func test_concat() async {
         let clock = TestClock()
 
-        let first = Effects.Just(Action.first).any
+        let first = Effects.Just(Action.first).eraseToAnyEffect()
         let second = Effects.Single {
             try! await clock.sleep(for: .seconds(300))
             return Action.second
-        }.any
+        }.eraseToAnyEffect()
         let third = Effects.Single {
             try! await clock.sleep(for: .seconds(200))
             return Action.third
-        }.any
+        }.eraseToAnyEffect()
         let fourth = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.fourth
-        }.any
-        let fifth = Effects.Just(Action.fifth).any
+        }.eraseToAnyEffect()
+        let fifth = Effects.Just(Action.fifth).eraseToAnyEffect()
 
         let values = Effects.Concat([
             first,
@@ -140,27 +140,27 @@ final class EffectTests: XCTestCase {
         let first = Effects.Single {
             try! await clock.sleep(for: .seconds(500))
             return Action.first
-        }.any
+        }.eraseToAnyEffect()
         let second = Effects.Single {
             try! await clock.sleep(for: .seconds(200))
             return Action.second
-        }.any
+        }.eraseToAnyEffect()
         let third = Effects.Single {
             try! await clock.sleep(for: .seconds(300))
             return Action.third
-        }.any
+        }.eraseToAnyEffect()
         let fourth = Effects.Single {
             try! await clock.sleep(for: .seconds(400))
             return Action.fourth
-        }.any
+        }.eraseToAnyEffect()
         let fifth = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.fifth
-        }.any
+        }.eraseToAnyEffect()
 
         let values = Effects.Concat([
             first,
-            Effects.Merge([fourth, third, second]).any,
+            Effects.Merge([fourth, third, second]).eraseToAnyEffect(),
             fifth,
         ]).values
 
@@ -188,23 +188,23 @@ final class EffectTests: XCTestCase {
         let first = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.first
-        }.any
+        }.eraseToAnyEffect()
         let second = Effects.Single {
             try! await clock.sleep(for: .seconds(200))
             return Action.second
-        }.any
+        }.eraseToAnyEffect()
         let third = Effects.Single {
             try! await clock.sleep(for: .seconds(300))
             return Action.third
-        }.any
+        }.eraseToAnyEffect()
         let fourth = Effects.Single {
             try! await clock.sleep(for: .seconds(400))
             return Action.fourth
-        }.any
+        }.eraseToAnyEffect()
         let fifth = Effects.Single {
             try! await clock.sleep(for: .seconds(500))
             return Action.fifth
-        }.any
+        }.eraseToAnyEffect()
 
         let values = Effects.Merge([
             first,
@@ -238,27 +238,27 @@ final class EffectTests: XCTestCase {
         let first = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.first
-        }.any
+        }.eraseToAnyEffect()
         let second = Effects.Single {
             try! await clock.sleep(for: .seconds(300))
             return Action.second
-        }.any
+        }.eraseToAnyEffect()
         let third = Effects.Single {
             try! await clock.sleep(for: .seconds(200))
             return Action.third
-        }.any
+        }.eraseToAnyEffect()
         let fourth = Effects.Single {
             try! await clock.sleep(for: .seconds(100))
             return Action.fourth
-        }.any
+        }.eraseToAnyEffect()
         let fifth = Effects.Single {
             try! await clock.sleep(for: .seconds(600 + 100))
             return Action.fifth
-        }.any
+        }.eraseToAnyEffect()
 
         let values = Effects.Merge([
             first,
-            Effects.Concat([second, third, fourth]).any,
+            Effects.Concat([second, third, fourth]).eraseToAnyEffect(),
             fifth,
         ]).values
 


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

- Changed the name from "any" to "eraseToAnyEffect" for clarity.

### Additional Notes 📚

```swift
// AS-IS
Effects.Just(element).any

// TO-BE
Effects.Just(element).eraseToAnyEffect()
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
