### PR TITLE
Enable the cancellation of the effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,52 @@ for await number in store.states.number.removeDuplicates() {
 // Prints "10"
 ```
 
+### Cancelling Effects
+
+You can make an effect capable of being canceled by using `cancellable()`. And you can use `cancel()` to cancel a cancellable effect.
+
+```swift
+func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
+    switch action {
+// ...
+    case .request:
+        return .single {
+            let result = await api.result()
+            return Action.response(result)
+        }
+        .cancellable("requestID")
+
+    case .cancel:
+        return .cancel("requestID")
+// ...
+    }
+}
+```
+
+You can assign anything that conforms [Hashable](https://developer.apple.com/documentation/swift/hashable) as an identifier for the effect, not just a string.
+
+```swift
+enum EffectID {
+    case request
+}
+
+func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
+    switch action {
+// ...
+    case .request:
+        return .single {
+            let result = await api.result()
+            return Action.response(result)
+        }
+        .cancellable(EffectID.request)
+
+    case .cancel:
+        return .cancel(EffectID.request)
+// ...
+    }
+}
+```
+
 ### Various Effects
 
 **OneWay** supports various effects such as `just`, `concat`, `merge`, `single`, `sequence`, and more. For more details, please refer to the [documentation](https://swiftpackageindex.com/devyeom/oneway/main/documentation/oneway/effects).

--- a/Sources/OneWay/AnyEffect.swift
+++ b/Sources/OneWay/AnyEffect.swift
@@ -9,6 +9,19 @@ import Foundation
 
 /// An effect that performs type erasure by wrapping another effect.
 public struct AnyEffect<Element>: Effect where Element: Sendable {
+    /// A convenience type alias for representing a hashable identifier.
+    public typealias EffectID = Hashable & Sendable
+
+    /// Enumeration of methods representing additional functionality for AnyEffect.
+    public enum Method: Sendable {
+        case register(any EffectID)
+        case cancel(any EffectID)
+        case none
+    }
+
+    /// A method of the AnyEffect
+    public var method: Method = .none
+
     public var values: AsyncStream<Element> { base.values }
 
     private var base: any Effect<Element>
@@ -19,6 +32,18 @@ public struct AnyEffect<Element>: Effect where Element: Sendable {
     public init<Base>(_ base: Base)
     where Base: Effect, Base.Element == Element {
         self.base = base
+    }
+
+    /// Assigning an identifier to make it possible to cancel the effect.
+    ///
+    /// - Parameter id: The effect's identifier.
+    /// - Returns: A new effect that can be canceled by an identifier.
+    public consuming func cancellable(
+        _ id: some EffectID
+    ) -> AnyEffect {
+        var copy = self
+        copy.method = .register(id)
+        return copy
     }
 }
 
@@ -39,6 +64,19 @@ extension AnyEffect {
         _ element: Element
     ) -> AnyEffect<Element> {
         Effects.Just(element).eraseToAnyEffect()
+    }
+
+    /// An effect that allows canceling by using an identifier.
+    ///
+    /// - Parameter id: The identifier of the effect to be canceled.
+    /// - Returns: A new effect.
+    @inlinable
+    public static func cancel(
+        _ id: some EffectID
+    ) -> AnyEffect {
+        var copy = AnyEffect.none
+        copy.method = .cancel(id)
+        return copy
     }
 
     /// An effect that can supply a single value asynchronously in the future.

--- a/Tests/OneWayTests/EffectTests.swift
+++ b/Tests/OneWayTests/EffectTests.swift
@@ -30,7 +30,29 @@ final class EffectTests: XCTestCase {
         XCTAssertEqual(result, [.first])
     }
 
-    func test_async() async {
+    func test_cancel() async {
+        let cancel = AnyEffect<Action>.cancel("100")
+        let method = cancel.method
+
+        if case .cancel(let id) = method {
+            XCTAssertEqual(id as! String, "100")
+        } else {
+            XCTFail()
+        }
+    }
+
+    func test_cancellable() async {
+        let effect = Effects.Just("").eraseToAnyEffect().cancellable("100")
+        let method = effect.method
+
+        if case .register(let id) = method {
+            XCTAssertEqual(id as! String, "100")
+        } else {
+            XCTFail()
+        }
+    }
+
+    func test_single() async {
         let clock = TestClock()
 
         let values = Effects.Single {


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

- Added methods to `AnyEffect` to cancel effects.
- Updated the documentation.

### Additional Notes 📚

```swift
func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
    switch action {
// ...
    case .request:
        return .single {
            let result = await api.result()
            return Action.response(result)
        }
        .cancellable("requestID")

    case .cancel:
        return .cancel("requestID")
// ...
    }
}
```

```swift
enum EffectID {
    case request
}

func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
    switch action {
// ...
    case .request:
        return .single {
            let result = await api.result()
            return Action.response(result)
        }
        .cancellable(EffectID.request)

    case .cancel:
        return .cancel(EffectID.request)
// ...
    }
}
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
