### PR TITLE
Add a test helper function for asynchronous tests

### DIFF
--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -48,26 +48,18 @@ final class StoreTests: XCTestCase {
         await sut.send(.increment)
         await sut.send(.twice)
 
-        while await sut.state.count < 4 {
-            await Task.yield()
-        }
-
-        let state = await sut.state
-        XCTAssertEqual(state.count, 4)
-        XCTAssertEqual(state.text, "")
+        await expect { await sut.state.count == 4 }
+        await expect { await sut.state.text == "" }
     }
 
     func test_lotsOfActions() async {
         let iterations: Int = 100_000
         await sut.send(.incrementMany)
 
-        while await sut.state.count < iterations {
-            await Task.yield()
-        }
-
-        let state = await sut.state
-        XCTAssertEqual(state.count, iterations)
-        XCTAssertEqual(state.text, "")
+        await expect(
+            compare: { await sut.state.count == iterations },
+            timeout: 10
+        )
     }
 
     func test_threadSafeSendingActions() async {
@@ -87,25 +79,16 @@ final class StoreTests: XCTestCase {
             }
         }
 
-        while await sut.state.count < iterations {
-            await Task.yield()
-        }
-
-        let state = await sut.state
-        XCTAssertEqual(state.count, iterations)
-        XCTAssertEqual(state.text, "")
+        await expect(
+            compare: { await sut.state.count == iterations },
+            timeout: 10
+        )
     }
 
     func test_asyncAction() async {
         await sut.send(.request)
 
-        while await sut.state.text.isEmpty {
-            await Task.yield()
-        }
-
-        let state = await sut.state
-        XCTAssertEqual(state.count, 0)
-        XCTAssertEqual(state.text, "Success")
+        await expect { await sut.state.text == "Success" }
     }
 
     func test_bind() async {

--- a/Tests/OneWayTests/TestHelper/XCTestCase+Expect.swift
+++ b/Tests/OneWayTests/TestHelper/XCTestCase+Expect.swift
@@ -1,0 +1,31 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022-2023 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import XCTest
+
+extension XCTestCase {
+    func expect(
+        compare: () async -> Bool,
+        timeout seconds: UInt64 = 1,
+        description: String = #function
+    ) async {
+        let limit = NSEC_PER_SEC * seconds
+        let start = DispatchTime.now().uptimeNanoseconds
+        while true {
+            guard start.distance(to: DispatchTime.now().uptimeNanoseconds) < limit else {
+                XCTFail("Exceeded timeout of \(seconds) seconds")
+                break
+            }
+            if await compare() {
+                XCTAssert(true)
+                break
+            } else {
+                await Task.yield()
+            }
+        }
+    }
+}

--- a/Tests/OneWayTests/ViewStoreTests.swift
+++ b/Tests/OneWayTests/ViewStoreTests.swift
@@ -41,11 +41,7 @@ final class ViewStoreTests: XCTestCase {
         sut.send(.increment)
         sut.send(.twice)
 
-        while sut.state.count < 4 {
-            await Task.yield()
-        }
-
-        XCTAssertEqual(sut.state.count, 4)
+        await expect { sut.state.count == 4 }
     }
 
     func test_sensitiveState() async {


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

- Added a test helper function because the code repeatedly used `Task.yield()` multiple times for comparing result values.

### Additional Notes 📚

```swift
// AS-IS
while await sut.state.count < 4 {
    await Task.yield()
}
let state = await sut.state
XCTAssertEqual(state.count, 4)

// TO-DO
await expect { await sut.state.count == 4 }
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
