### PR TITLE
Add a debouncing operator

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Related Issues 💭
 
-<!-- If an related issue doesn't exist, remove this section. -->
+<!-- If no related issues exist, remove this section. -->
 
 ### Description 📝
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 **OneWay** is a remarkably simple and lightweight library designed for state management through unidirectional data flow. It is implemented based on [Swift Concurrency](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/). The `Store` is implemented with an `Actor`, making it always **thread-safe**.
 
-Whether you're working on any platform or within any framework, **OneWay** can seamlessly integrate. With zero third-party dependencies, **OneWay** can be used in its purest form. This library isn't limited to be used just the presentation layer. It's also useful for streamlining intricate business logic. You'll find it beneficial whenever you seek to implement logic in a unidirectional manner.
+Whether you're working on any platform or within any framework, **OneWay** can seamlessly integrate. With zero third-party dependencies, **OneWay** can be used in its purest form. This library isn't limited to use only for the presentation layer. It's also useful for streamlining intricate business logic. You'll find it beneficial whenever you seek to implement logic in a unidirectional manner.
 
 > [!NOTE]
 > OneWay is a good solution for preparing Swift 6.
@@ -79,8 +79,10 @@ struct CountingReducer: Reducer {
         case .twice:
             return .concat(
                 .just(.setIsLoading(true)),
-                .just(.increment),
-                .just(.increment),
+                .merge(
+                    .just(.increment),
+                    .just(.increment),
+                ),
                 .just(.setIsLoading(false))
             )
 
@@ -241,7 +243,7 @@ func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
 
 ### External States
 
-You can easily receive to global states by implementing `bind()`. If there are changes in publishers or streams that necessitate rebinding, you can call `reset()` of `Store`.
+You can easily receive to external states by implementing `bind()`. If there are changes in publishers or streams that necessitate rebinding, you can call `reset()` of `Store`.
 
 ```swift
 let textPublisher = PassthroughSubject<String, Never>()

--- a/Sources/OneWay/AnyEffect.swift
+++ b/Sources/OneWay/AnyEffect.swift
@@ -48,11 +48,11 @@ public struct AnyEffect<Element>: Effect where Element: Sendable {
     ///
     /// - Parameters:
     ///   - id: The effect's identifier.
-    ///   - dueTime: The duration for which the effect should wait before sending an element.
+    ///   - seconds: The duration for which the effect should wait before sending an element.
     /// - Returns: A new effect that sends elements only after a specified time elapses.
     public consuming func debounce(
         id: some EffectID,
-        for dueTime: Double
+        for seconds: Double
     ) -> Self {
         var copy = self
         copy.method = .register(id, cancelInFlight: true)
@@ -62,7 +62,7 @@ public struct AnyEffect<Element>: Effect where Element: Sendable {
                 let NSEC_PER_SEC = 1_000_000_000 as Double
                 for await value in values {
                     guard !Task.isCancelled else { return }
-                    let dueTime = NSEC_PER_SEC * dueTime
+                    let dueTime = NSEC_PER_SEC * seconds
                     try? await Task.sleep(nanoseconds: UInt64(dueTime))
                     guard !Task.isCancelled else { return }
                     send(value)

--- a/Sources/OneWay/OneWay.docc/OneWay.md
+++ b/Sources/OneWay/OneWay.docc/OneWay.md
@@ -35,8 +35,10 @@ struct CountingReducer: Reducer {
         case .twice:
             return .concat(
                 .just(.setIsLoading(true)),
-                .just(.increment),
-                .just(.increment),
+                .merge(
+                    .just(.increment),
+                    .just(.increment),
+                ),
                 .just(.setIsLoading(false))
             )
 

--- a/Sources/OneWay/Store.swift
+++ b/Sources/OneWay/Store.swift
@@ -92,7 +92,11 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
             tasks[taskID] = task
 
             switch effect.method {
-            case .register(let id):
+            case let .register(id, cancelInFlight):
+                if cancelInFlight {
+                    let taskIDs = cancellables[_EffectID(id), default: []]
+                    taskIDs.forEach { removeTask($0) }
+                }
                 cancellables[_EffectID(id), default: []].insert(taskID)
 
             case .cancel(let id):

--- a/Tests/OneWayTests/EffectTests.swift
+++ b/Tests/OneWayTests/EffectTests.swift
@@ -45,7 +45,7 @@ final class EffectTests: XCTestCase {
         let effect = Effects.Just("").eraseToAnyEffect().cancellable("100")
         let method = effect.method
 
-        if case let .register(id, cancelInFlight) = method {
+        if case let .register(id, _) = method {
             XCTAssertEqual(id as! String, "100")
         } else {
             XCTFail()

--- a/Tests/OneWayTests/EffectTests.swift
+++ b/Tests/OneWayTests/EffectTests.swift
@@ -45,7 +45,7 @@ final class EffectTests: XCTestCase {
         let effect = Effects.Just("").eraseToAnyEffect().cancellable("100")
         let method = effect.method
 
-        if case .register(let id) = method {
+        if case let .register(id, cancelInFlight) = method {
             XCTAssertEqual(id as! String, "100")
         } else {
             XCTFail()


### PR DESCRIPTION
### Related Issues 💭

<!-- If an related issue doesn't exist, remove this section. -->

### Description 📝

Add a new operator that sends elements only after a specified time interval elapses between events.

### Additional Notes 📚

```swift
enum Debounce {
    case increment
}
func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
    switch action {
// ...
    case .debounce:
        return .just(.increment)
            .debounce(id: Debounce.increment, for: 0.5)

    case .debounceWithClock:
        return .just(.increment)
            .debounce(id: Debounce.increment, for: .seconds(1), clock: .continuous)
// ...
    }
}
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
