### PR TITLE
Remove equatable requirement from insensitve property

### DIFF
--- a/Sources/OneWay/PropertyWrappers/Insensitive.swift
+++ b/Sources/OneWay/PropertyWrappers/Insensitive.swift
@@ -26,7 +26,7 @@ extension Insensitive: CustomStringConvertible {
 }
 
 extension Insensitive: Sendable where Value: Sendable { }
-extension Insensitive: Equatable where Value: Equatable {
+extension Insensitive: Equatable {
     public static func == (lhs: Insensitive, rhs: Insensitive) -> Bool {
         true
     }


### PR DESCRIPTION
### Related Issues 💭

### Description 📝
Remove `equatable` requirement from wrappedValue of `@Insensitive`

### Additional Notes 📚
As the `==` function in Insensitive always returns true, making `equatable` conformance unnecessary for the value.

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
