### PR TITLE
Reduce the timeout of Github Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   test:
     runs-on: macos-13
-    timeout-minutes: 60
+    timeout-minutes: 30
     env:
       SCHEME: OneWay
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ struct CountingReducer: Reducer {
                 .just(.setIsLoading(true)),
                 .merge(
                     .just(.increment),
-                    .just(.increment),
+                    .just(.increment)
                 ),
                 .just(.setIsLoading(false))
             )

--- a/Sources/OneWay/OneWay.docc/OneWay.md
+++ b/Sources/OneWay/OneWay.docc/OneWay.md
@@ -37,7 +37,7 @@ struct CountingReducer: Reducer {
                 .just(.setIsLoading(true)),
                 .merge(
                     .just(.increment),
-                    .just(.increment),
+                    .just(.increment)
                 ),
                 .just(.setIsLoading(false))
             )


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- The timeout, which was set at 60 minutes, has been reduced to 30 minutes, considering the time taken for CI workflows.

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
