### PR TITLE
Update the view store tests with `expect` function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.0'
+        xcode-version: '15.1'
     - name: Build and Test
       run: make test-all

--- a/Tests/OneWayTests/EffectTests.swift
+++ b/Tests/OneWayTests/EffectTests.swift
@@ -10,6 +10,7 @@ import OneWay
 import XCTest
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+@MainActor
 final class EffectTests: XCTestCase {
     enum Action: Sendable {
         case first

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -158,8 +158,7 @@ final class StoreTests: XCTestCase {
         }
     }
 
-    /// To prevent potential hangs in GitHub Actions, it is temporarily excluded.
-    func _test_debounce() async {
+    func test_debounce() async {
         for _ in 0..<5 {
             try! await Task.sleep(nanoseconds: NSEC_PER_MSEC * 100)
             await sut.send(.debouncedIncrement)
@@ -205,8 +204,7 @@ final class StoreTests: XCTestCase {
         await expect { await sut.state.count == 2 }
     }
 
-    /// To prevent potential hangs in GitHub Actions, it is temporarily excluded.
-    func _test_deboouncedSequence() async {
+    func test_deboouncedSequence() async {
         for _ in 0..<5 {
             try! await Task.sleep(nanoseconds: NSEC_PER_MSEC * 100)
             await sut.send(.debouncedSequence)


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- Applied the `expect` function to ensure fast failure and increase test reliability.
- Reverted #61 

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
