### PR TITLE
Add Binder for swiftui

### DIFF
--- a/Sources/OneWay/Store.swift
+++ b/Sources/OneWay/Store.swift
@@ -40,7 +40,7 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
 
     private let reducer: any Reducer<Action, State>
     private let continuation: AsyncStream<State>.Continuation
-    private var isProcessing: Bool = false
+    public private(set) var isProcessing: Bool = false
     private var actionQueue: [Action] = []
     private var bindingTask: Task<Void, Never>?
     private var tasks: [TaskID: Task<Void, Never>] = [:]


### PR DESCRIPTION
### Related Issues 💭
I want to make sugar for just setter value  on State for ViewStore when i use SwiftUI. Thus I suggest binder using keypath to setter for oneway 


### Description 📝
Lets suppose i use simple textfield app

```swift
import Foundation
import SwiftUI
import OneWay


struct OneWayView1: View {
    @StateObject var store: ViewStore<OneWayReducer1> = .init(reducer: .init(), state: .init())
    var body: some View {
        VStack {
            
            TextField("TextField", text: $store.state.searchText)
                .task {
                    
                    for await searchText in store.states.searchText {
                        // Problem line1
                        print("🥶\(#file) \(#line) \(searchText)")
                    }
                }
            
            Button("buttonbutton") {
                store.send(.tapButtonForDebug)
            }
        }
    }
}

class OneWayReducer1: Reducer {
    enum Action {
        case setSearchText(String)
        case tapButtonForDebug
        
    }
    
    struct State: Equatable {
        var searchText: String = ""
    }
        
    func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
        switch action {
        case let .setSearchText(value):
            state.searchText = value
            return .none
            
        case .tapButtonForDebug:
            // Problem line2
            print("🥶\(#file) \(#line) \(state.searchText)")
            return .none
        }
    }
}

```

I marked two line which both prints out. And when i types like "Hello OneWay", `Problem Line1` would be print 
" H", "He".... "Hello OneWay". However when i clicked, button which leads to Action.tapButtonForDebug prints out nothing but "" <- which is state.searchText. 

So on this problem, i mostly used to handle this problem like adding Binder like 

```swift

extension OneWayView1 {
    var searchTextBinder: Binding<String> {
        .init {
            store.state.searchText
        } set: { newText in
            store.send(.setSearchText(newText))
        }
    }
}

```

You know whenever it is getting more and more properties on State, this binder makes code much larger, thats why i open this PR.

Expected result would be better than above code.

```
TextField("TextField", text: store.binder(\.searchText))
```



### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
