### PR TITLE
Add store's action queue state on ViewStore and modify private only setter

### DIFF
--- a/Sources/OneWay/Store.swift
+++ b/Sources/OneWay/Store.swift
@@ -40,8 +40,8 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
 
     private let reducer: any Reducer<Action, State>
     private let continuation: AsyncStream<State>.Continuation
-    public private(set) var isProcessing: Bool = false
-    public private(set) var actionQueue: [Action] = []
+    private var isProcessing: Bool = false
+    private var actionQueue: [Action] = []
     private var bindingTask: Task<Void, Never>?
     private var tasks: [TaskID: Task<Void, Never>] = [:]
     private var cancellables: [_EffectID: Set<TaskID>] = [:]

--- a/Sources/OneWay/Store.swift
+++ b/Sources/OneWay/Store.swift
@@ -40,8 +40,8 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
 
     private let reducer: any Reducer<Action, State>
     private let continuation: AsyncStream<State>.Continuation
-    private var isProcessing: Bool = false
-    private var actionQueue: [Action] = []
+    public private(set) var isProcessing: Bool = false
+    public private(set) var actionQueue: [Action] = []
     private var bindingTask: Task<Void, Never>?
     private var tasks: [TaskID: Task<Void, Never>] = [:]
     private var cancellables: [_EffectID: Set<TaskID>] = [:]

--- a/Sources/OneWay/Store.swift
+++ b/Sources/OneWay/Store.swift
@@ -26,7 +26,7 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
     public let initialState: State
 
     /// The current state of a store.
-    public var state: State {
+    public private(set) var state: State {
         didSet {
             if oldValue != state {
                 continuation.yield(state)

--- a/Sources/OneWay/ViewStore.swift
+++ b/Sources/OneWay/ViewStore.swift
@@ -26,7 +26,7 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
     public let initialState: State
 
     /// The current state of a store.
-    public var state: State {
+    public private(set) var state: State {
         didSet {
             continuation.yield(state)
             states.send(state)
@@ -91,6 +91,20 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
     ///   directly
     public func reset() {
         Task { await store.reset() }
+    }
+}
+
+extension ViewStore {
+    public var isProcessing: Bool {
+        get async {
+            await store.isProcessing
+        }
+    }
+    
+    public var isActionQueueEmpty: Bool {
+        get async {
+            await store.actionQueue.isEmpty
+        }
     }
 }
 

--- a/Sources/OneWay/ViewStore.swift
+++ b/Sources/OneWay/ViewStore.swift
@@ -94,20 +94,6 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
     }
 }
 
-extension ViewStore {
-    public var isProcessing: Bool {
-        get async {
-            await store.isProcessing
-        }
-    }
-    
-    public var isActionQueueEmpty: Bool {
-        get async {
-            await store.actionQueue.isEmpty
-        }
-    }
-}
-
 #if canImport(Combine)
 extension ViewStore: ObservableObject { }
 #endif


### PR DESCRIPTION
### Related Issues 💭
I have two suggestion's for ViewStore.

One is making a limitation for allowing setter on public.
The other one is let viewstore be able to know of store's state, especially actionQueue.

### Description 📝

<!-- Please include a summary of the changes or improvements you have made. -->

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
