### PR TITLE
Update `swift-clocks` to v1.0.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG] "
+title: ''
 labels: bug
 assignees: DevYeom
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "d1fd837326aa719bee979bdde1f53cd5797443eb",
-        "version" : "1.0.0"
+        "revision" : "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
+        "version" : "1.0.2"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "ea631ce892687f5432a833312292b80db238186a",
-        "version" : "1.0.0"
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Tests/OneWayTests/EffectTests.swift
+++ b/Tests/OneWayTests/EffectTests.swift
@@ -10,7 +10,6 @@ import OneWay
 import XCTest
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
-@MainActor
 final class EffectTests: XCTestCase {
     enum Action: Sendable {
         case first


### PR DESCRIPTION
### Related Issues 💭

Resolves #65 

### Description 📝

- There is an update related to hanging issues in `swift-clocks`, so I updated it.
- To resolve warnings, I applied strict concurrency to `ViewStoreTests`.

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
