### PR TITLE
Add effects result builder for sugar

### DIFF
--- a/Sources/OneWay/AnyEffect.swift
+++ b/Sources/OneWay/AnyEffect.swift
@@ -189,6 +189,17 @@ extension AnyEffect {
             effects
         ).eraseToAnyEffect()
     }
+    
+    @inlinable
+    public static func concat(
+        priority: TaskPriority? = nil,
+        @EffectsBuilder _ effects: () -> [AnyEffect<Element>]
+    ) -> AnyEffect<Element> {
+        Effects.Concat(
+            priority: priority,
+            effects()
+        ).eraseToAnyEffect()
+    }
 
     /// An effect that merges a list of effects together into a single effect, which runs the
     /// effects at the same time.
@@ -206,6 +217,17 @@ extension AnyEffect {
         Effects.Merge(
             priority: priority,
             effects
+        ).eraseToAnyEffect()
+    }
+    
+    @inlinable
+    public static func merge(
+        priority: TaskPriority? = nil,
+        @EffectsBuilder _ effects: () -> [AnyEffect<Element>]
+    ) -> AnyEffect<Element> {
+        Effects.Merge(
+            priority: priority,
+            effects()
         ).eraseToAnyEffect()
     }
 }

--- a/Sources/OneWay/EffectBuilder.swift
+++ b/Sources/OneWay/EffectBuilder.swift
@@ -1,0 +1,15 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022-2023 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import Foundation
+
+@resultBuilder
+public struct EffectsBuilder {    
+    public static func buildBlock<T: Sendable>(_ effects: AnyEffect<T>...) -> [AnyEffect<T>] {
+        return effects
+    }
+}


### PR DESCRIPTION
### Related Issues 💭
Add result builder for effects.

### Description 📝
Added result builder for effects.merge and concat


can use like
```swift

//..

 return .concat(
  .increase,
  .increase,
  .increase
)
//.. can be like

 return .concat {
  .increase
  .increase
  .increase
}
```

### Checklist ✅

- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
