### PR TITLE
Add `Create` effect that creates an asynchronous stream

### DIFF
--- a/Sources/OneWay/AnyEffect.swift
+++ b/Sources/OneWay/AnyEffect.swift
@@ -246,4 +246,25 @@ extension AnyEffect {
             build()
         ).eraseToAnyEffect()
     }
+
+    /// An effect that creates an asynchronous stream.
+    ///
+    /// - Parameters:
+    ///   - bufferingPolicy: A `Continuation.BufferingPolicy` value to set the stream's buffering
+    ///   behavior. By default, the stream buffers an unlimited number of elements. You can also set
+    ///   the policy to buffer a specified number of oldest or newest elements.
+    ///   - build: A custom closure that yields values to the `AsyncStream`. This closure receives
+    ///   an `AsyncStream.Continuation` instance that it uses to provide elements to the stream and
+    ///   terminate the stream when finished.
+    /// - Returns: A new effect.
+    @inlinable
+    public static func create(
+        bufferingPolicy: AsyncStream<Element>.Continuation.BufferingPolicy = .unbounded,
+        build: @escaping (AsyncStream<Element>.Continuation) -> Void
+    ) -> AnyEffect<Element> {
+        Effects.Create(
+            bufferingPolicy: bufferingPolicy,
+            build: build
+        ).eraseToAnyEffect()
+    }
 }

--- a/Sources/OneWay/Effect.swift
+++ b/Sources/OneWay/Effect.swift
@@ -203,4 +203,29 @@ public enum Effects {
             }
         }
     }
+
+    /// An effect that creates an asynchronous stream.
+    public struct Create<Element>: Effect where Element: Sendable {
+        private let stream: AsyncStream<Element>
+
+        /// Initializes a `Create` effect.
+        ///
+        /// - Parameters:
+        ///   - bufferingPolicy: A `Continuation.BufferingPolicy` value to set the stream's
+        ///   buffering behavior. By default, the stream buffers an unlimited number of elements.
+        ///   You can also set the policy to buffer a specified number of oldest or newest elements.
+        ///   - build: A custom closure that yields values to the `AsyncStream`. This closure
+        ///   receives an `AsyncStream.Continuation` instance that it uses to provide elements to
+        ///   the stream and terminate the stream when finished.
+        public init(
+            bufferingPolicy: AsyncStream<Element>.Continuation.BufferingPolicy = .unbounded,
+            build: @escaping (AsyncStream<Element>.Continuation) -> Void
+        ) {
+            self.stream = AsyncStream<Element>(bufferingPolicy: bufferingPolicy, build)
+        }
+
+        public var values: AsyncStream<Element> {
+            stream
+        }
+    }
 }


### PR DESCRIPTION
### Related Issues 💭

Resolves #69 

### Description 📝

- Add `Create` effect that creates an asynchronous stream.
- Add unit tests for `Create` effect.

### Additional Notes 📚

```swift
func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
    switch action {
// ...
        case .twice:
            return .create { continuation in
                continuation.yield(.increment)
                continuation.yield(.increment)
                continuation.finish()
            }
// ...
    }
}
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
