### PR TITLE
Update the supporting platforms and the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    runs-on: macos-13
+  ci:
+    runs-on: macos-14
     timeout-minutes: 30
     env:
       SCHEME: OneWay
@@ -23,6 +23,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: '15.1'
-    - name: Build and Test
+        xcode-version: '15.2'
+    - name: Build and test
       run: make test-all

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PLATFORM_IOS = iOS Simulator,name=iPhone 15
 PLATFORM_MACOS = macOS
 PLATFORM_TVOS = tvOS Simulator,name=Apple TV
+PLATFORM_VISIONOS = visionOS Simulator,name=Apple Vision Pro
 PLATFORM_WATCHOS = watchOS Simulator,name=Apple Watch Series 9 (45mm)
 CONFIG = debug
 
@@ -15,6 +16,7 @@ test:
 		"$(PLATFORM_IOS)" \
 		"$(PLATFORM_MACOS)" \
 		"$(PLATFORM_TVOS)" \
+		"$(PLATFORM_VISIONOS)" \
 		"$(PLATFORM_WATCHOS)"; \
 	do \
 		xcodebuild clean build test \

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
         .macOS(.v10_15),
         .tvOS(.v13),
         .watchOS(.v6),
+        .visionOS(.v1),
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ To learn how to use **OneWay** in more detail, go through the [documentation](ht
 
 ## Requirements
 
-| OneWay | Swift | Xcode | Platforms                                     |
-|--------|-------|-------|-----------------------------------------------|
-| 2.0    | 5.9   | 15.0  | iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0 |
-| 1.0    | 5.5   | 13.0  | iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0 |
+| OneWay | Swift | Xcode | Platforms                                                   |
+|--------|-------|-------|-------------------------------------------------------------|
+| 2.0    | 5.9   | 15.0  | iOS 13.0, macOS 10.15, tvOS 13.0, visionOS 1.0, watchOS 6.0 |
+| 1.0    | 5.5   | 13.0  | iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0               |
 
 ## Installation
 


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- Add `visionOS` to supporting platforms.
- Update the CI workflow to run on macOS 14.

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
