### PR TITLE
Run a clean build in every CI workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build:
 		"$(PLATFORM_VISIONOS)" \
 		"$(PLATFORM_WATCHOS)"; \
 	do \
-		xcodebuild build \
+		xcodebuild clean build \
 			-scheme OneWay \
 			-configuration $(CONFIG) \
 			-destination platform="$$platform" || exit 1; \


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- To resolve an error like the one below, run a clean build in every CI workflow.

### Additional Notes 📚

```
error: failed to deserialize Info.plist task context: 
fopen(/Users/runner/Library/Developer/Xcode/DerivedData/OneWay-atdipbrljqzjyyfrugshnxivuwel/Build/Intermediates.noindex/XCBuildData/44ee71b410e4e4a4a5855b65159a8a90.xcbuilddata/attachments/5d262ee73eda39a247afbe8381921866,
rb): No such file or directory (2) (in target 'OneWayTests' from project 'OneWay')
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
