### PR TITLE
Enhance the processing performance of the store in multi-threaded environments

### DIFF
--- a/Sources/OneWay/Store.swift
+++ b/Sources/OneWay/Store.swift
@@ -44,7 +44,7 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
     private var actionQueue: [Action] = []
     private var bindingTask: Task<Void, Never>?
     private var tasks: [TaskID: Task<Void, Never>] = [:]
-    private var cancellables: [_EffectID: Set<TaskID>] = [:]
+    private var cancellables: [EffectIDWrapper: Set<TaskID>] = [:]
 
     /// Initializes a store from a reducer and an initial state.
     ///
@@ -95,13 +95,13 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
             switch effect.method {
             case let .register(id, cancelInFlight):
                 if cancelInFlight {
-                    let taskIDs = cancellables[_EffectID(id), default: []]
+                    let taskIDs = cancellables[EffectIDWrapper(id), default: []]
                     taskIDs.forEach { removeTask($0) }
                 }
-                cancellables[_EffectID(id), default: []].insert(taskID)
+                cancellables[EffectIDWrapper(id), default: []].insert(taskID)
 
             case .cancel(let id):
-                let taskIDs = cancellables[_EffectID(id), default: []]
+                let taskIDs = cancellables[EffectIDWrapper(id), default: []]
                 taskIDs.forEach { removeTask($0) }
 
             case .none:
@@ -142,7 +142,7 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
     }
 }
 
-private struct _EffectID: Hashable, @unchecked Sendable {
+private struct EffectIDWrapper: Hashable, @unchecked Sendable {
     private let id: AnyHashable
 
     fileprivate init(_ id: some Hashable & Sendable) {

--- a/Sources/OneWay/Store.swift
+++ b/Sources/OneWay/Store.swift
@@ -75,10 +75,11 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
     public func send(_ action: Action) async {
         actionQueue.append(action)
         guard !isProcessing else { return }
-
         isProcessing = true
-        while !actionQueue.isEmpty {
-            let action = actionQueue.removeFirst()
+        await Task.yield()
+        let count = actionQueue.count
+        for index in Int.zero ..< count {
+            let action = actionQueue[index]
             let taskID = TaskID()
             let effect = reducer.reduce(state: &state, action: action)
             let task = Task { [weak self, taskID] in
@@ -107,6 +108,7 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
                 break
             }
         }
+        actionQueue = []
         isProcessing = false
     }
 

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -68,7 +68,7 @@ final class StoreTests: XCTestCase {
     }
 
     func test_threadSafeSendingActions() async {
-        let iterations: Int = 10_000
+        let iterations: Int = 100_000
         let sut = sut!
         DispatchQueue.concurrentPerform(
             iterations: iterations / 2,


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- Change the method of handling the action queue from `O(n)` to `O(1)`

### Additional Notes 📚

- Test: Measuring the total time taken by concurrently sending 100,000 actions to the store.
- Iterations: 100 times
- Environment: M2 Max (Sonoma 14.3)

| AS-IS | TO-BE |
|--------|--------|
| 58.9065s | 0.4535s | 

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
