### PR TITLE
Reduce CI timeout duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   macos:
     runs-on: macos-14
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode
@@ -27,7 +27,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
     - name: Test

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 	done;
 
 test-swift:
-	swift test --parallel -c debug
-	swift test --parallel -c release
+	swift test -c debug
+	swift test -c release
 
 .PHONY: build-all build test-swift

--- a/Tests/OneWayTests/EffectTests.swift
+++ b/Tests/OneWayTests/EffectTests.swift
@@ -61,7 +61,7 @@ final class EffectTests: XCTestCase {
         }.values
 
         var result: [Action] = []
-        await clock.advance(by: .seconds(100))
+        Task { await clock.advance(by: .seconds(100 + 1)) }
         for await value in values {
             result.append(value)
         }
@@ -138,7 +138,7 @@ final class EffectTests: XCTestCase {
         ]).values
 
         var result: [Action] = []
-        await clock.advance(by: .seconds(100 + 200 + 300))
+        Task { await clock.advance(by: .seconds(100 + 200 + 300 + 1)) }
         for await value in values {
             result.append(value)
         }
@@ -187,7 +187,7 @@ final class EffectTests: XCTestCase {
         ]).values
 
         var result: [Action] = []
-        await clock.advance(by: .seconds(500 + 400 + 100))
+        Task { await clock.advance(by: .seconds(500 + 400 + 100 + 1)) }
         for await value in values {
             result.append(value)
         }
@@ -237,7 +237,7 @@ final class EffectTests: XCTestCase {
         ]).values
 
         var result: [Action] = []
-        await clock.advance(by: .seconds(500))
+        Task { await clock.advance(by: .seconds(500 + 1)) }
         for await value in values {
             result.append(value)
         }
@@ -285,7 +285,7 @@ final class EffectTests: XCTestCase {
         ]).values
 
         var result: [Action] = []
-        await clock.advance(by: .seconds(700))
+        Task { await clock.advance(by: .seconds(700 + 1)) }
         for await value in values {
             result.append(value)
         }
@@ -351,7 +351,7 @@ final class EffectTests: XCTestCase {
         }.values
 
         var result: [Action] = []
-        await clock.advance(by: .seconds(300))
+        Task { await clock.advance(by: .seconds(300 + 1)) }
         for await value in values {
             result.append(value)
         }

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -141,11 +141,14 @@ final class StoreTests: XCTestCase {
 
     func test_cancel() async {
         do {
-            await sut.send(.longTimeTask)
-            await clock.advance(by: .seconds(200))
+            let before = await sut.state.text
+            XCTAssertEqual(before, "")
 
-            let text = await sut.state.text
-            XCTAssertEqual(text, "Success")
+            await sut.send(.longTimeTask)
+            await clock.advance(by: .seconds(200 + 1))
+
+            let after = await sut.state.text
+            XCTAssertEqual(after, "Success")
         }
 
         await sut.send(.response(""))


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- Change CI timeout duration from 30m to 10m

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
