### PR TITLE
Add `Sendable` to key path literals

### DIFF
--- a/Sources/OneWay/AsyncSequences/AsyncViewStateSequence.swift
+++ b/Sources/OneWay/AsyncSequences/AsyncViewStateSequence.swift
@@ -63,6 +63,18 @@ where State: Sendable & Equatable {
     ///
     /// - Parameter dynamicMember: a key path for the original state.
     /// - Returns: A new stream that has a part of the original state.
+    #if swift(>=6)
+    public subscript<Property>(
+        dynamicMember keyPath: KeyPath<State, Property> & Sendable
+    ) -> AsyncMapSequence<AsyncStream<State>, Property> {
+        let (stream, continuation) = AsyncStream<Element>.makeStream()
+        continuations.append(continuation)
+        if let last {
+            continuation.yield(last)
+        }
+        return stream.map { $0[keyPath: keyPath] }
+    }
+    #else
     public subscript<Property>(
         dynamicMember keyPath: KeyPath<State, Property>
     ) -> AsyncMapSequence<AsyncStream<State>, Property> {
@@ -73,6 +85,7 @@ where State: Sendable & Equatable {
         }
         return stream.map { $0[keyPath: keyPath] }
     }
+    #endif
 }
 
 extension AsyncViewStateSequence: Sendable where State: Sendable { }

--- a/Tests/OneWayTests/TestHelper/Publisher+Async.swift
+++ b/Tests/OneWayTests/TestHelper/Publisher+Async.swift
@@ -8,7 +8,7 @@
 #if canImport(Combine)
 @preconcurrency import Combine
 
-extension Publisher where Failure == Never {
+extension Publisher where Failure == Never, Output: Sendable {
     public var stream: AsyncStream<Output> {
         AsyncStream { continuation in
             let cancellable = self.sink { completion in


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- Resolved concurrency warnings related to key paths
- Verified successful build in `Xcode 16.0 Beta 6`
- Achieved 0 warnings

### Additional Notes 📚

- [0418-inferring-sendable-for-methods](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0418-inferring-sendable-for-methods.md)

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
