### PR TITLE
Add missing swift build for linux ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
+    - name: Build Swift
+      run: make build-swift
     - name: Run Swift Tests
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,7 @@ test-swift6:
 	swift package clean
 	swift test -Xswiftc -swift-version -Xswiftc 6
 
+build-swift:
+	swift build
+
 .PHONY: build-all build test test-swift6

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ test-swift6:
 build-swift:
 	swift build
 
-.PHONY: build-all build test test-swift6
+.PHONY: build-all build test test-swift6 build-swift

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -61,7 +61,7 @@ final class StoreTests: XCTestCase {
     func test_lotsOfActions() async {
         let iterations: Int = 100_000
         await sut.send(.incrementMany)
-        await sut.expect(\.count, iterations, timeout: 5)
+        await sut.expect(\.count, iterations, timeout: 10)
     }
 
     func test_threadSafeSendingActions() async {


### PR DESCRIPTION
### Description 📝

OneWay is a swift library for state management regardless of platforms even if it is not contains apple enviroment. As Swift and Foundation became as an open source. Compilable and runnable on linux would get mattering. Thus validating build before merge can be very important

I personally had experienced swift-foundation's missing function which is not building on linux even working on macos. Moreover as introducing Concurrency, Foundation has got missing more and more refactored-async-concurrency methods. [For in my case](https://forums.swift.org/t/does-concurrency-work-in-docker/72235), Foundation missed URLSession's concurrency function.

As OneWay's main is concurrency, I think build-checking is crucial so I suggest swift build not only testing

