### PR TITLE
Improve the debounce performance

### DIFF
--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -323,7 +323,7 @@ private struct TestReducer: Reducer {
 
         case .longTimeTask:
             return .single {
-                try! await clock.sleep(for: .seconds(200))
+                try? await clock.sleep(for: .seconds(200))
                 return Action.response("Success")
             }
             .cancellable(EffectID.longTimeTask)


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- Updated to immediately stop the effect if a cancellation error is received during debouncing.
- Modified so that task cancellation is propagated to the effect's async stream.
- Updated the documentation.

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
