### PR TITLE
Add throttle operator

### DIFF
--- a/Sources/OneWay/Store.swift
+++ b/Sources/OneWay/Store.swift
@@ -8,6 +8,9 @@
 #if canImport(Foundation)
 import Foundation
 #endif
+#if canImport(CoreFoundation)
+import CoreFoundation
+#endif
 
 /// `Store` is an actor that holds and manages state values.
 ///
@@ -53,6 +56,9 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
     private var bindingTask: Task<Void, Never>?
     private var tasks: [TaskID: Task<Void, Never>] = [:]
     private var cancellables: [EffectIDWrapper: Set<TaskID>] = [:]
+    private var throttleTimestamps: [EffectIDWrapper: any Sendable] = [:]
+    private var throttleTimestampsUsingAbsoluteTime: [EffectIDWrapper: CFAbsoluteTime] = [:]
+    private var trailingThrottledEffects: [EffectIDWrapper: AnyEffect<Action>] = [:]
 
     /// Initializes a store from a reducer and an initial state.
     ///
@@ -86,35 +92,15 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
         isProcessing = true
         await Task.yield()
         for action in actionQueue {
-            let taskID = TaskID()
             let effect = reducer.reduce(state: &state, action: action)
-            let task = Task { [weak self, taskID] in
-                guard !Task.isCancelled else { return }
-                for await value in effect.values {
-                    guard let self else { break }
-                    guard !Task.isCancelled else { break }
-                    await send(value)
-                }
-                await self?.removeTask(taskID)
+            let isThrottled: Bool
+            if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+                isThrottled = await throttleIfNeeded(for: effect)
+            } else {
+                isThrottled = await throttleIfNeededUsingAbsoluteTime(for: effect)
             }
-            tasks[taskID] = task
-
-            switch effect.method {
-            case let .register(id, cancelInFlight):
-                let effectID = EffectIDWrapper(id)
-                if cancelInFlight {
-                    let taskIDs = cancellables[effectID, default: []]
-                    taskIDs.forEach { removeTask($0) }
-                    cancellables.removeValue(forKey: effectID)
-                }
-                cancellables[effectID, default: []].insert(taskID)
-            case let .cancel(id):
-                let effectID = EffectIDWrapper(id)
-                let taskIDs = cancellables[effectID, default: []]
-                taskIDs.forEach { removeTask($0) }
-                cancellables.removeValue(forKey: effectID)
-            case .none:
-                break
+            if !isThrottled {
+                await execute(effect: effect)
             }
         }
         actionQueue = []
@@ -130,6 +116,128 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
         tasks.forEach { $0.value.cancel() }
         tasks.removeAll()
         actionQueue.removeAll()
+        cancellables.removeAll()
+        trailingThrottledEffects.removeAll()
+        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+            throttleTimestamps.removeAll()
+        } else {
+            throttleTimestampsUsingAbsoluteTime.removeAll()
+        }
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    private func throttleIfNeeded(for effect: AnyEffect<Action>) async -> Bool {
+        guard case let .throttle(id, interval, latest) = effect.method else {
+            return false
+        }
+        let effectID = EffectIDWrapper(id)
+        let clock = ContinuousClock()
+        let now = clock.now
+        if let last = throttleTimestamps[effectID] as? ContinuousClock.Instant {
+            if last.duration(to: now) < .seconds(interval) {
+                print("🔥 interval1", last.duration(to: now), "<" , interval, state)
+            } else {
+                print("🔥 interval1", last.duration(to: now), ">" , interval, state)
+            }
+        }
+        if let last = throttleTimestamps[effectID] as? ContinuousClock.Instant,
+           last.duration(to: now) < .seconds(interval) {
+            if latest {
+                trailingThrottledEffects[effectID] = effect
+            }
+            return true
+        } else {
+            if throttleTimestamps[effectID] == nil {
+                print("🔥 new", state)
+            }
+            throttleTimestamps[effectID] = now
+            if latest {
+                Task { [weak self] in
+                    do {
+                        try await clock.sleep(for: .seconds(interval))
+                        await self?.executeTrailingThrottledEffects(effectID)
+                    }
+                    catch {
+                        await self?.removeTrailingThrottledEffects(effectID)
+                    }
+                }
+            }
+            return false
+        }
+    }
+
+    private func throttleIfNeededUsingAbsoluteTime(for effect: AnyEffect<Action>) async -> Bool {
+        guard case let .throttle(id, interval, latest) = effect.method else {
+            return false
+        }
+        let effectID = EffectIDWrapper(id)
+        let now = CFAbsoluteTimeGetCurrent()
+        if let last = throttleTimestampsUsingAbsoluteTime[effectID],
+           (now - last) < interval {
+            if latest {
+                trailingThrottledEffects[effectID] = effect
+            }
+            return true
+        } else {
+            throttleTimestampsUsingAbsoluteTime[effectID] = now
+            if latest {
+                Task { [weak self] in
+                    do {
+                        let NSEC_PER_SEC: Double = 1_000_000_000
+                        let nanoseconds = UInt64(interval * NSEC_PER_SEC)
+                        try await Task.sleep(nanoseconds: nanoseconds)
+                        await self?.executeTrailingThrottledEffects(effectID)
+                    }
+                    catch {
+                        await self?.removeTrailingThrottledEffects(effectID)
+                    }
+                }
+            }
+            return false
+        }
+    }
+
+    private func execute(effect: AnyEffect<Action>) async {
+        let taskID = TaskID()
+        let task = Task { [weak self, taskID] in
+            guard !Task.isCancelled else { return }
+            for await value in effect.values {
+                guard let self else { break }
+                guard !Task.isCancelled else { break }
+                await send(value)
+            }
+            await self?.removeTask(taskID)
+        }
+        tasks[taskID] = task
+
+        switch effect.method {
+        case let .register(id, cancelInFlight):
+            let effectID = EffectIDWrapper(id)
+            if cancelInFlight {
+                let taskIDs = cancellables[effectID, default: []]
+                taskIDs.forEach { removeTask($0) }
+                cancellables.removeValue(forKey: effectID)
+            }
+            cancellables[effectID, default: []].insert(taskID)
+        case let .cancel(id):
+            let effectID = EffectIDWrapper(id)
+            let taskIDs = cancellables[effectID, default: []]
+            taskIDs.forEach { removeTask($0) }
+            cancellables.removeValue(forKey: effectID)
+        case .throttle,
+             .none:
+            break
+        }
+    }
+
+    private func executeTrailingThrottledEffects(_ effectID: EffectIDWrapper) async {
+        if let effect = trailingThrottledEffects.removeValue(forKey: effectID) {
+            await execute(effect: effect)
+        }
+    }
+
+    private func removeTrailingThrottledEffects(_ effectID: EffectIDWrapper) async {
+        trailingThrottledEffects.removeValue(forKey: effectID)
     }
 
     private func bindExternalEffect() {

--- a/Sources/OneWayTesting/Store+Testing.swift
+++ b/Sources/OneWayTesting/Store+Testing.swift
@@ -69,7 +69,7 @@ extension Store {
             #if canImport(XCTest)
             if isTimeout && result != input {
                 XCTFail(
-                    "Exceeded timeout of \(timeout) seconds",
+                    "Timeout exceeded \(timeout) seconds: received \(input), expected \(result)",
                     file: filePath,
                     line: line
                 )
@@ -87,7 +87,7 @@ extension Store {
         case .testing:
             if isTimeout && result != input {
                 Issue.record(
-                    "Exceeded timeout of \(timeout) seconds",
+                    "Timeout exceeded \(timeout) seconds: received \(input), expected \(result)",
                     sourceLocation: Testing.SourceLocation(
                         fileID: String(describing: fileID),
                         filePath: String(describing: filePath),
@@ -156,7 +156,7 @@ extension Store {
             #if canImport(XCTest)
             if isTimeout && result != input {
                 XCTFail(
-                    "Exceeded timeout of \(timeout) seconds",
+                    "Timeout exceeded \(timeout) seconds: received \(input), expected \(result)",
                     file: filePath,
                     line: line
                 )
@@ -174,7 +174,7 @@ extension Store {
         case .testing:
             if isTimeout && result != input {
                 Issue.record(
-                    "Exceeded timeout of \(timeout) seconds",
+                    "Timeout exceeded \(timeout) seconds: received \(input), expected \(result)",
                     sourceLocation: Testing.SourceLocation(
                         fileID: String(describing: fileID),
                         filePath: String(describing: filePath),


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- Add a new operator that emits elements from this effect, but only if a certain amount of time has passed between emissions.

### Additional Notes 📚

```swift
enum ThrottleID {
    case button
}

func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
    switch action {
    // ...
    case .perform:
        return .just(.increment)
            .throttle(id: ThrottleID.button, for: 1.0, latest: true)
    // ...
    }
}
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
