### PR TITLE
Add throttle operator

### DIFF
--- a/Sources/OneWayTesting/Store+Testing.swift
+++ b/Sources/OneWayTesting/Store+Testing.swift
@@ -69,7 +69,7 @@ extension Store {
             #if canImport(XCTest)
             if isTimeout && result != input {
                 XCTFail(
-                    "Exceeded timeout of \(timeout) seconds",
+                    "Timeout exceeded \(timeout) seconds: received \(input), expected \(result)",
                     file: filePath,
                     line: line
                 )
@@ -87,7 +87,7 @@ extension Store {
         case .testing:
             if isTimeout && result != input {
                 Issue.record(
-                    "Exceeded timeout of \(timeout) seconds",
+                    "Timeout exceeded \(timeout) seconds: received \(input), expected \(result)",
                     sourceLocation: Testing.SourceLocation(
                         fileID: String(describing: fileID),
                         filePath: String(describing: filePath),
@@ -156,7 +156,7 @@ extension Store {
             #if canImport(XCTest)
             if isTimeout && result != input {
                 XCTFail(
-                    "Exceeded timeout of \(timeout) seconds",
+                    "Timeout exceeded \(timeout) seconds: received \(input), expected \(result)",
                     file: filePath,
                     line: line
                 )
@@ -174,7 +174,7 @@ extension Store {
         case .testing:
             if isTimeout && result != input {
                 Issue.record(
-                    "Exceeded timeout of \(timeout) seconds",
+                    "Timeout exceeded \(timeout) seconds: received \(input), expected \(result)",
                     sourceLocation: Testing.SourceLocation(
                         fileID: String(describing: fileID),
                         filePath: String(describing: filePath),

--- a/Tests/OneWayTests/ViewStoreTests.swift
+++ b/Tests/OneWayTests/ViewStoreTests.swift
@@ -11,7 +11,7 @@ import XCTest
 #if !os(Linux)
 final class ViewStoreTests: XCTestCase {
     @MainActor
-    private var sut: ViewStore<TestReducer>!
+    private var sut: ViewStore<TestReducer, ContinuousClock>!
 
     @MainActor
     override func setUp() async throws {


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- Add a new operator that emits elements from this effect, but only if a certain amount of time has passed between emissions.

### Additional Notes 📚

```swift
enum ThrottleID {
    case button
}

func reduce(state: inout State, action: Action) -> AnyEffect<Action> {
    switch action {
    // ...
    case .perform:
        return .just(.increment)
            .throttle(id: ThrottleID.button, for: .seconds(1), latest: true)
    // ...
    }
}
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.