### PR TITLE
Add logging for actions and state changes

### DIFF
--- a/Sources/OneWay/LoggingOptions.swift
+++ b/Sources/OneWay/LoggingOptions.swift
@@ -1,0 +1,29 @@
+//
+//  OneWay
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2022-2025 SeungYeop Yeom ( https://github.com/DevYeom ).
+//
+
+import Foundation
+
+/// A set of options that determines what information is logged by a ``Store``.
+public struct LoggingOptions: OptionSet, Sendable {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    /// Logs all actions sent to the store.
+    public static let action = LoggingOptions(rawValue: 1 << 0)
+
+    /// Logs all state changes in the store.
+    public static let state = LoggingOptions(rawValue: 1 << 1)
+
+    /// Logs all actions and state changes.
+    public static let all: LoggingOptions = [.action, .state]
+
+    /// Disables all logging.
+    public static let none: LoggingOptions = []
+}

--- a/Sources/OneWay/ViewStore.swift
+++ b/Sources/OneWay/ViewStore.swift
@@ -101,6 +101,33 @@ where R.Action: Sendable, R.State: Sendable & Equatable {
             await store.reset()
         }
     }
+
+    /// Sets the logging options for the store to control what information is logged.
+    ///
+    /// You can use this method to dynamically change the logging behavior of the store after it
+    /// has been initialized. For example, you might want to enable logging only for certain
+    /// user interactions or when debugging a specific issue.
+    ///
+    /// ```swift
+    /// // Enable logging for both actions and state changes.
+    /// @StateObject private var store = ViewStore(
+    ///     reducer: HomeReducer(),
+    ///     state: HomeReducer.State()
+    /// )
+    /// .debug(.all)
+    ///
+    /// // Disable all logging.
+    /// store.debug(.none)
+    /// ```
+    ///
+    /// - Parameter loggingOptions: A set of `LoggingOptions` that determines what information
+    ///   is logged.
+    public func debug(_ loggingOptions: LoggingOptions) -> Self {
+        Task { @MainActor in
+            await store.debug(loggingOptions)
+        }
+        return self
+    }
 }
 
 #if canImport(Combine)

--- a/Tests/OneWayTests/StoreTests.swift
+++ b/Tests/OneWayTests/StoreTests.swift
@@ -50,6 +50,7 @@ final class StoreTests: XCTestCase {
     }
 
     func test_sendSeveralActions() async {
+        await sut.debug(.all)
         await sut.send(.increment)
         await sut.send(.increment)
         await sut.send(.twice)
@@ -235,6 +236,18 @@ final class StoreTests: XCTestCase {
 
         await clock.advance(by: .seconds(100))
         await sut.expect(\.count, 4)
+    }
+
+    func test_logging_options() async {
+        let all = Store(
+            reducer: TestReducer(clock: TestClock()),
+            state: TestReducer.State(count: 0, text: ""),
+            loggingOptions: .all
+        )
+        await all.debug(.all)
+        await all.debug(.none)
+        await all.debug(.action)
+        await all.debug(.state)
     }
 }
 

--- a/Tests/OneWayTests/ViewStoreTests.swift
+++ b/Tests/OneWayTests/ViewStoreTests.swift
@@ -178,6 +178,17 @@ final class ViewStoreTests: XCTestCase {
             ]
         )
     }
+
+    func test_logging_options() async {
+        let _ = await ViewStore(
+            reducer: TestReducer(),
+            state: TestReducer.State(count: 0)
+        )
+        .debug(.all)
+        .debug(.none)
+        .debug(.action)
+        .debug(.state)
+    }
 }
 
 private struct TestReducer: Reducer {


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- This PR introduces a configurable logging mechanism to the Store to help with debugging. Developers can now enable logging for actions and state changes, with fine-grained control over what is logged.

### Additional Notes 📚

```swift
@StateObject private var store = ViewStore(
    reducer: HomeReducer(),
    state: HomeReducer.State()
)
.debug(.all)
```

```
[2025-11-09T04:42:58.956Z] Action: increment
[2025-11-09T04:42:58.956Z] State changed:
- State(count: 0, text: "")
+ State(count: 1, text: "")
[2025-11-09T04:42:58.956Z] Action: increment
[2025-11-09T04:42:58.956Z] State changed:
- State(count: 1, text: "")
+ State(count: 2, text: "")
[2025-11-09T04:42:58.956Z] Action: twice
[2025-11-09T04:42:58.956Z] Action: increment
[2025-11-09T04:42:58.957Z] State changed:
- State(count: 2, text: "")
+ State(count: 3, text: "")
[2025-11-09T04:42:58.957Z] Action: increment
[2025-11-09T04:42:58.957Z] State changed:
- State(count: 3, text: "")
+ State(count: 4, text: "")
```

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
