### PR TITLE
Run CI builds for Swift 6 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,7 @@ jobs:
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
     - name: Run Swift Tests
-      run: |
-        make test
-        make test-swift6
+      run: make test
     - name: Build for All Platforms
       run: make build-all
 

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,7 @@ test:
 	swift package clean
 	swift test
 
-test-swift6:
-	swift package clean
-	swift test -Xswiftc -swift-version -Xswiftc 6
-
 build-swift:
 	swift build
 
-.PHONY: build-all build test test-swift6 build-swift
+.PHONY: build-all build test build-swift


### PR DESCRIPTION
### Related Issues 💭

<!-- If no related issues exist, remove this section. -->

### Description 📝

- Starting from version 3.0, it supports Swift 6.

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
