### PR TITLE
Update Xcode version to 26.5 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app
     - name: Build for All Platforms
       run: make build-all
     - name: Run Swift Tests


### PR DESCRIPTION
### Description 📝

- Update Xcode version from `26.0.1` to `26.5`

### Additional Notes 📚

<!-- Add any additional notes or context about the changes made. -->

### Checklist ✅

- [x] If it's a new feature, have appropriate unit tests been added?
- [x] If the changes affect existing functionality, please verify whether the above information has been appropriately described.
